### PR TITLE
Fix remote attacks applying damage twice in online play

### DIFF
--- a/__tests__/kidsfight_scene_handle_remote_action.test.ts
+++ b/__tests__/kidsfight_scene_handle_remote_action.test.ts
@@ -69,7 +69,9 @@ describe('KidsFightScene.handleRemoteAction', () => {
     const now = Date.now();
     (scene as any).tryAttack.mockClear();
     scene.handleRemoteAction({ type: 'attack', playerIndex: 0, now });
-    expect((scene as any).tryAttack).toHaveBeenCalledTimes(2);
+    // A remote attack must apply exactly once, otherwise damage is doubled on
+    // the receiving client.
+    expect((scene as any).tryAttack).toHaveBeenCalledTimes(1);
   });
 
   it('sets attack animation on correct player during remote attack', () => {
@@ -80,8 +82,8 @@ describe('KidsFightScene.handleRemoteAction', () => {
     // Handle remote attack from player 0 (guest attacking)
     scene.handleRemoteAction({ type: 'attack', playerIndex: 0, now: Date.now() });
     
-    // Verify tryAttack was called with correct attacker index
-    expect((scene as any).tryAttack).toHaveBeenCalledWith(0, player0, player1, expect.any(Number), false);
+    // Verify tryAttack was called once with the canonical (attackerIdx, defenderIdx, now, special) signature
+    expect((scene as any).tryAttack).toHaveBeenCalledTimes(1);
     expect((scene as any).tryAttack).toHaveBeenCalledWith(0, 1, expect.any(Number), false);
     
     // Restore original function
@@ -115,7 +117,8 @@ describe('KidsFightScene.handleRemoteAction', () => {
     const now = Date.now();
     (scene as any).tryAttack.mockClear();
     scene.handleRemoteAction({ type: 'special', playerIndex: 1, now });
-    expect((scene as any).tryAttack).toHaveBeenCalledTimes(2);
+    // A remote special must apply exactly once (see attack case above).
+    expect((scene as any).tryAttack).toHaveBeenCalledTimes(1);
   });
 
   it('handles position_update action', () => {

--- a/kidsfight_scene.ts
+++ b/kidsfight_scene.ts
@@ -1958,9 +1958,10 @@ export default class KidsFightScene extends Phaser.Scene {
           console.log('[SCENE][DEBUG] Attacker exists, texture:', attacker.texture?.key || 'unknown');
         }
 
-        // Call both signatures for test compatibility
+        // Apply the remote attack exactly once. Calling tryAttack more than
+        // once here double-applies damage on the receiving client and desyncs
+        // health between host and guest.
         this.tryAttack(action.playerIndex, defenderIdx, timestamp, false);
-        this.tryAttack(action.playerIndex, attacker, defender, timestamp, false);
         break;
       }
       case 'special': {
@@ -1971,8 +1972,8 @@ export default class KidsFightScene extends Phaser.Scene {
         const attacker = this.players?.[action.playerIndex];
         const defender = this.players?.[defenderIdx];
         const timestamp = action.now ?? Date.now();
+        // Apply the remote special exactly once (see attack case above).
         this.tryAttack(action.playerIndex, defenderIdx, timestamp, true);
-        this.tryAttack(action.playerIndex, attacker, defender, timestamp, true);
         break;
       }
       case 'position_update': {


### PR DESCRIPTION
## Problem

`handleRemoteAction` called `tryAttack` **twice** for every incoming remote attack/special, with a code comment admitting it was "for test compatibility":

```ts
this.tryAttack(action.playerIndex, defenderIdx, timestamp, false);
this.tryAttack(action.playerIndex, attacker, defender, timestamp, false);
```

`tryAttack` accepts both signatures but resolves them to the same attacker/defender and subtracts `damage` from `playerHealth` on **each** call. So on the receiving client:

- a normal remote hit dealt **10 damage instead of 5**
- a remote special dealt **20 instead of 10** and consumed special pips twice

The attacking client applied single damage locally, so **health desynced between host and guest on every hit** — a core multiplayer-breaking bug.

## Fix

Apply each remote attack/special exactly once, using the canonical `(attackerIdx, defenderIdx, now, special)` signature that the rest of the combat code uses.

The `handle_remote_action` tests literally asserted `toHaveBeenCalledTimes(2)` and both signatures — i.e. they encoded the bug. Updated them to expect a single canonical call.

## Testing

- `kidsfight_scene_handle_remote_action.test.ts`, `handle_remote_action.test.ts` — pass (20 tests)
- Related online/combat/health suites (`online_health_sync`, `kidsfight_scene_online_mode[.fixed]`, `kidsfight_scene_online_attack_animation`, `damage_calculation`, `kidsfight_scene_health_and_attack_logic`) — pass (40 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches online combat sync (`handleRemoteAction` / `tryAttack`); wrong behavior would break multiplayer fairness, but the change is a narrow bugfix with updated tests.
> 
> **Overview**
> Fixes **host/guest health desync** when one player hits the other online: incoming remote **attack** and **special** actions no longer run combat twice on the peer that receives them.
> 
> `handleRemoteAction` previously invoked `tryAttack` **twice** per remote hit (index-based and sprite-object overloads “for test compatibility”). Each call applied damage and special-pip logic, so the receiving client took **2× damage** while the attacker applied a single hit locally.
> 
> The handler now calls `tryAttack` **once** with the canonical `(attackerIdx, defenderIdx, now, special)` signature for both attack and special. Unit tests that asserted two calls were updated to expect a single canonical invocation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b73f2928b3e2fcb48a243186c2173208b5c9bf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->