### PR TITLE
Load scenario3 background so the third stage renders

### DIFF
--- a/kidsfight_scene.ts
+++ b/kidsfight_scene.ts
@@ -1,6 +1,7 @@
 import Phaser from 'phaser';
 import scenario1Img from './scenario1.png';
 import scenario2Img from './scenario2.png';
+import scenario3Img from './scenario3.png';
 import player1RawImg from './sprites-bento3.png';
 import player2RawImg from './sprites-davir3.png';
 import player3RawImg from './sprites-jose3.png';
@@ -612,6 +613,7 @@ export default class KidsFightScene extends Phaser.Scene {
     // Backgrounds
     this.load.image('scenario1', scenario1Img);
     this.load.image('scenario2', scenario2Img);
+    this.load.image('scenario3', scenario3Img);
 
     // Player raw sprites for variable-width spritesheets
     this.load.image('bento_raw', player1RawImg);


### PR DESCRIPTION
## Problem

`ScenarioSelectScene` defines **three** stages and lets the player cycle through all of them:

```ts
{ key: 'scenario3', name: 'Ronivaldo Pinto', img: scenario3Img },
```

But `KidsFightScene.preload` only loaded `scenario1` and `scenario2`. Selecting the third stage passed `scenarioKey='scenario3'` to `safeAddImage(400, 240, 'scenario3')`, referencing a texture that was never loaded → the battle rendered Phaser's **missing-texture placeholder** instead of a background. Fully reachable from the UI.

## Fix

Import `scenario3.png` (the asset already exists in the repo, 1.9 MB) and `load.image('scenario3', …)` alongside the other two. The background is rendered directly from the key, so no other change is needed.

## Testing

- `character_scenario_selection` + `kidsfight_scene_cross_and_flip` suites pass; the `.png` import resolves under jest.

> Note: `CLAUDE.md` still says "2 battle scenarios" — worth updating separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two-line asset preload fix in the fight scene; no auth, networking, or combat logic changes.
> 
> **Overview**
> **Fixes missing background** when players pick the third stage from scenario select.
> 
> `KidsFightScene` now **imports** `scenario3.png` and registers **`load.image('scenario3', …)`** in `preload`, matching how `scenario1` and `scenario2` are loaded. Selection already passed `scenario3` into `safeAddImage`; without this preload, Phaser showed the missing-texture placeholder.
> 
> No gameplay or selection logic changes—only asset loading parity with `ScenarioSelectScene`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cef0a15adfc809cede82d111c61622448c6e5655. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->