### PR TITLE
Fix WebSocketManager.connect() opening the wrong URL

### DIFF
--- a/kidsfight_scene.ts
+++ b/kidsfight_scene.ts
@@ -588,7 +588,10 @@ export default class KidsFightScene extends Phaser.Scene {
       if (typeof global !== 'undefined') {
         (global as any).mockWsManager = this.wsManager;
       }
-      if (this.wsManager?.connect) this.wsManager.connect(this.roomCode);
+      // Pass the room code as the roomCode argument (2nd param); the manager
+      // resolves the server URL itself. Passing it as the URL made connect()
+      // try to open the room code as a WebSocket endpoint.
+      if (this.wsManager?.connect) this.wsManager.connect(undefined, this.roomCode);
       this.wsManager?.setMessageCallback?.((msg: any) => {
         console.log('[SCENE][DEBUG] Received WebSocket message:', msg);
         // First try to extract action from msg.action, msg.data, or use the message itself

--- a/websocket_manager.d.ts
+++ b/websocket_manager.d.ts
@@ -16,7 +16,7 @@ declare class WebSocketManager {
     static getInstance(webSocketFactory?: (url: string) => WebSocket): WebSocketManager;
     static resetInstance(): void;
 
-    connect(url?: string): WebSocket | null;
+    connect(url?: string, roomCode?: string): WebSocket | null;
     disconnect(): void;
     isConnected(): boolean;
     send(message: any): boolean;

--- a/websocket_manager.ts
+++ b/websocket_manager.ts
@@ -98,19 +98,22 @@ class WebSocketManager {
   public async connect(url?: string, roomCode?: string): Promise<WebSocket> {
     console.log('[WSM][DIAG] connect() called', { url, roomCode });
     // Use Render in production, localhost in development
-    let wsUrl = url;
-    if (!wsUrl) {
-      wsUrl = getWebSocketUrl();
+    const wsUrl: string = url || getWebSocketUrl();
+    // Remember the room code if the caller supplied one so it is attached to
+    // outgoing messages (see send()).
+    if (roomCode) {
+      this._roomCode = roomCode;
     }
     if (this._ws) {
       console.warn(`[WSM] WebSocket already connected [${this._debugInstanceId}]`);
       return Promise.resolve(this._ws);
     }
-    
+
     return new Promise((resolve, reject) => {
       try {
         this._isHost = false;
-        this._ws = this._webSocketFactory(url!);
+        // Connect to the resolved URL, not the raw (possibly undefined) argument.
+        this._ws = this._webSocketFactory(wsUrl);
         console.log('[WSM][DIAG] _ws created', { ws: !!this._ws, url: this._ws?.url });
         
         // Set up event handlers


### PR DESCRIPTION
## Problem

`connect(url?, roomCode?)` resolved the server URL into `wsUrl` (falling back to `getWebSocketUrl()`) but then created the socket from the **raw argument**:

```ts
const wsUrl = url || getWebSocketUrl();
...
this._ws = this._webSocketFactory(url!);   // ← ignores wsUrl
```

Consequences:
- `connect()` with no args → `new WebSocket(undefined)`
- `KidsFightScene` called `connect(this.roomCode)` → the room code (e.g. `"111111"`) was passed into the **URL** slot, so it tried to open the room code as a WebSocket endpoint
- the `roomCode` parameter was never stored in `_roomCode`

This only "worked" because the singleton was usually already connected from `OnlineModeScene`, so `connect()` early-returned. Any path where the socket wasn't already open — rejoin, reload straight into the battle scene, a dropped connection — failed to reconnect.

## Fix

- Create the socket from the resolved `wsUrl`, not the raw arg.
- Store the `roomCode` argument in `_roomCode` (so `send()` attaches it).
- Fix the `KidsFightScene` caller to pass the room code as the 2nd argument (`connect(undefined, this.roomCode)`).
- Update the `connect()` signature in `websocket_manager.d.ts` to include `roomCode`.

## Testing

- All 10 websocket/online-mode suites pass (88 tests).
- `tsc` introduces no new errors in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core online connectivity and message routing; behavior improves on reconnect/reload paths but any missed `connect()` call sites could still pass room codes as URLs.
> 
> **Overview**
> Fixes **online WebSocket reconnect** when the battle scene opens without an existing socket from the lobby.
> 
> **`WebSocketManager.connect()`** now opens the socket with the resolved `wsUrl` (`url` override or `getWebSocketUrl()`), not the raw first argument—so bare `connect()` no longer becomes `new WebSocket(undefined)`. An optional **`roomCode`** second argument is stored in `_roomCode` for outbound routing. The public **`.d.ts`** signature matches.
> 
> **`KidsFightScene`** online `init` calls **`connect(undefined, this.roomCode)`** so the room code is not mistaken for the WebSocket URL (e.g. `"111111"` as an endpoint).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a48f617e50bc1ed9d4577f67a104c5d6aaccb76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->