### PR TITLE
Synchronize blocking state in online play

### DIFF
--- a/__tests__/kidsfight_scene_touch_controls_blocking.test.ts
+++ b/__tests__/kidsfight_scene_touch_controls_blocking.test.ts
@@ -93,4 +93,19 @@ describe('KidsFightScene mobile touch controls - fight end blocking', () => {
     expect(player.setVelocityY).not.toHaveBeenCalled();
     expect(player.setData).not.toHaveBeenCalledWith('isBlocking', true);
   });
+
+  it('broadcasts block state to the opponent in online mode', () => {
+    scene.fightEnded = false;
+    scene.gameOver = false;
+    (scene as any).gameMode = 'online';
+    const send = jest.fn();
+    (scene as any).wsManager = { send };
+
+    blockBtn.emit('pointerdown');
+    // Must include the `active` flag; the receiver reads action.active.
+    expect(send).toHaveBeenCalledWith({ type: 'block', playerIndex: 0, active: true });
+
+    blockBtn.emit('pointerup');
+    expect(send).toHaveBeenCalledWith({ type: 'block', playerIndex: 0, active: false });
+  });
 });

--- a/kidsfight_scene.ts
+++ b/kidsfight_scene.ts
@@ -1554,6 +1554,10 @@ export default class KidsFightScene extends Phaser.Scene {
         player.setData('isBlocking', true);
         this.playerBlocking[idx] = true;
       }
+      // Tell the opponent we started blocking so their attacks are halved.
+      if (this.gameMode === 'online' && this.wsManager?.send) {
+        this.wsManager.send({ type: 'block', playerIndex: idx, active: true });
+      }
     });
 
     blockBtn.on('pointerup', () => {
@@ -1563,6 +1567,10 @@ export default class KidsFightScene extends Phaser.Scene {
       if (player) {
         player.setData('isBlocking', false);
         this.playerBlocking[idx] = false;
+      }
+      // Tell the opponent we stopped blocking.
+      if (this.gameMode === 'online' && this.wsManager?.send) {
+        this.wsManager.send({ type: 'block', playerIndex: idx, active: false });
       }
     });
 
@@ -1973,8 +1981,10 @@ export default class KidsFightScene extends Phaser.Scene {
         break;
       }
       case 'block': {
-        player.setData?.('isBlocking', action.active);
-        this.playerBlocking[action.playerIndex] = action.active;
+        // Coerce to a boolean: older/other senders may omit `active`.
+        const blocking = !!action.active;
+        player.setData?.('isBlocking', blocking);
+        this.playerBlocking[action.playerIndex] = blocking;
         break;
       }
       case 'attack': {
@@ -2949,8 +2959,8 @@ export default class KidsFightScene extends Phaser.Scene {
       this.playerBlocking[idx] = true;
     }
     if (this.gameMode === 'online' && this.wsManager?.send) {
-      this.wsManager.send({ type: 'block', playerIndex: idx });
-      
+      this.wsManager.send({ type: 'block', playerIndex: idx, active: true });
+
       // Send position update with blocking animation state
       if (player) {
         const vx = player.body?.velocity?.x ?? 0;


### PR DESCRIPTION
## Problem

Blocking was a complete no-op online:

- The touch **block button** updated only local state (`isBlocking` / `playerBlocking`) and sent **nothing** over the socket.
- `handleBlock()` (which isn't actually wired to any input) sent `{ type: 'block', playerIndex }` with **no `active` field**, while the remote receiver reads `action.active` → always `undefined`.
- There was **no "block released" message**, so a remote block could never be cleared.

Result: the opponent never learned a player was blocking, so `tryAttack`'s damage-halving for a blocking defender (`this.playerBlocking[defenderIdx]`) never triggered for a remote player. Blocking gave no defensive benefit online.

## Fix

- The touch block button now broadcasts `{ type:'block', playerIndex, active:true }` on **press** and `{ …, active:false }` on **release** when online.
- `handleBlock()` includes `active:true` for consistency.
- The remote `'block'` handler coerces `action.active` to a boolean defensively.

## Testing

- New regression test asserts the press/release broadcast with the `active` flag.
- All block/remote-action suites pass (now 36 tests across 5 suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes online combat sync and WebSocket message shape; behavior is localized to blocking but affects damage calculation when peers are on mismatched versions without `active`.
> 
> **Overview**
> **Online blocking now mirrors local play** so remote opponents see when someone is guarding and damage halving in `tryAttack` can apply.
> 
> Touch **block** press/release in online mode sends `{ type: 'block', playerIndex, active: true|false }` via `wsManager`. `handleBlock()` includes **`active: true`** on its block message (aligned with what `handleRemoteAction` expects).
> 
> The remote **`block`** handler coerces `action.active` with `!!action.active` so missing `active` from older clients reads as not blocking.
> 
> A regression test asserts touch block broadcasts press and release with the `active` flag in online mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7aed76e875d568416731831a5b8f8e3c00f4ff7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->