### PR TITLE
Wire keyboard keys to attack/special/jump/block actions

### DIFF
--- a/__tests__/keyboard_actions.test.ts
+++ b/__tests__/keyboard_actions.test.ts
@@ -1,0 +1,86 @@
+import KidsFightScene from '../kidsfight_scene';
+
+/**
+ * Regression tests for keyboard action keys (attack / special / jump / block).
+ * Before the fix these keys were created but never bound or polled, so desktop
+ * players could move but could not attack, block, jump, or use specials.
+ */
+describe('KidsFightScene.handleKeyboardActions', () => {
+  let scene: any;
+
+  const makeKey = () => ({ isDown: false });
+
+  beforeEach(() => {
+    scene = new KidsFightScene();
+    scene.gameOver = false;
+    scene.fightEnded = false;
+    scene.gameMode = 'local';
+    scene.players = [{ setData: jest.fn() }, { setData: jest.fn() }];
+    scene.playerBlocking = [false, false];
+    scene.getPlayerIndex = () => 0;
+
+    // Mocked action handlers
+    scene.handleAttack = jest.fn();
+    scene.handleSpecial = jest.fn();
+    scene.handleJumpDown = jest.fn();
+    scene.handleBlock = jest.fn();
+
+    // Mocked keys
+    scene.attackKey = makeKey();
+    scene.keySpace = makeKey();
+    scene.keyQ = makeKey();
+    scene.keyW = makeKey();
+    scene.blockKey = makeKey();
+    scene.keyShift = makeKey();
+    scene.cursors = { up: makeKey(), left: makeKey(), right: makeKey() };
+  });
+
+  it('fires attack once per key press (edge-triggered)', () => {
+    scene.attackKey.isDown = true;
+    scene.handleKeyboardActions(); // press
+    scene.handleKeyboardActions(); // still held
+    expect(scene.handleAttack).toHaveBeenCalledTimes(1);
+
+    scene.attackKey.isDown = false;
+    scene.handleKeyboardActions(); // release
+    scene.attackKey.isDown = true;
+    scene.handleKeyboardActions(); // press again
+    expect(scene.handleAttack).toHaveBeenCalledTimes(2);
+  });
+
+  it('fires special on Q press', () => {
+    scene.keyQ.isDown = true;
+    scene.handleKeyboardActions();
+    expect(scene.handleSpecial).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires jump on ArrowUp or W', () => {
+    scene.cursors.up.isDown = true;
+    scene.handleKeyboardActions();
+    expect(scene.handleJumpDown).toHaveBeenCalledTimes(1);
+
+    scene.cursors.up.isDown = false;
+    scene.handleKeyboardActions();
+    scene.keyW.isDown = true;
+    scene.handleKeyboardActions();
+    expect(scene.handleJumpDown).toHaveBeenCalledTimes(2);
+  });
+
+  it('engages block on key down and releases it on key up', () => {
+    scene.blockKey.isDown = true;
+    scene.handleKeyboardActions(); // engage
+    expect(scene.handleBlock).toHaveBeenCalledTimes(1);
+
+    scene.blockKey.isDown = false;
+    scene.handleKeyboardActions(); // release
+    expect(scene.players[0].setData).toHaveBeenCalledWith('isBlocking', false);
+    expect(scene.playerBlocking[0]).toBe(false);
+  });
+
+  it('does nothing when the game is over', () => {
+    scene.gameOver = true;
+    scene.attackKey.isDown = true;
+    scene.handleKeyboardActions();
+    expect(scene.handleAttack).not.toHaveBeenCalled();
+  });
+});

--- a/kidsfight_scene.ts
+++ b/kidsfight_scene.ts
@@ -317,6 +317,13 @@ export default class KidsFightScene extends Phaser.Scene {
   private keyShift!: Phaser.Input.Keyboard.Key;
   private keyEnter!: Phaser.Input.Keyboard.Key;
 
+  // Previous-frame key state, used for edge detection so held keys fire an
+  // action once per press instead of every frame.
+  private _prevAttackDown: boolean = false;
+  private _prevSpecialDown: boolean = false;
+  private _prevJumpDown: boolean = false;
+  private _prevBlockDown: boolean = false;
+
   private winnerIndex: number | undefined;
 
   constructor() {
@@ -2393,6 +2400,8 @@ export default class KidsFightScene extends Phaser.Scene {
 
     // Process keyboard input
     this.processKeyboardInput();
+    // Process keyboard action keys (attack / special / jump / block)
+    this.handleKeyboardActions();
 
     if (p1.x <= p2.x) {
       // Player 1 on the left facing right, Player 2 on the right facing left
@@ -2502,6 +2511,49 @@ export default class KidsFightScene extends Phaser.Scene {
         animation: 'walking'  // Send animation state directly
       });
     }
+  }
+
+  /**
+   * Poll the keyboard for the action keys (attack / special / jump / block) and
+   * dispatch them to the same handlers the on-screen touch buttons use.
+   * Attack, special and jump are edge-triggered (fire once per key press);
+   * block is a held state (engaged while the key is down, released on key-up).
+   *
+   * Unlike processKeyboardInput this is not gated behind a test guard, so it can
+   * be exercised directly with mocked keys.
+   */
+  public handleKeyboardActions(): void {
+    if (this.gameOver || (this as any)._gameOver || this.fightEnded) return;
+
+    const attackDown = !!(this.attackKey?.isDown || this.keySpace?.isDown);
+    const specialDown = !!this.keyQ?.isDown;
+    const jumpDown = !!(this.cursors?.up?.isDown || this.keyW?.isDown);
+    const blockDown = !!(this.blockKey?.isDown || this.keyShift?.isDown);
+
+    // Edge-triggered actions
+    if (attackDown && !this._prevAttackDown) this.handleAttack();
+    if (specialDown && !this._prevSpecialDown) this.handleSpecial();
+    if (jumpDown && !this._prevJumpDown) this.handleJumpDown();
+
+    // Block is held: engage on press, release on key-up
+    if (blockDown && !this._prevBlockDown) {
+      this.handleBlock();
+    } else if (!blockDown && this._prevBlockDown) {
+      const idx = this.getPlayerIndex();
+      const player = this.players?.[idx];
+      if (player) {
+        player.setData?.('isBlocking', false);
+        this.playerBlocking[idx] = false;
+      }
+      if (this.gameMode === 'online' && this.wsManager?.send) {
+        this.wsManager.send({ type: 'block', playerIndex: idx, active: false });
+      }
+    }
+
+    this._prevAttackDown = attackDown;
+    this._prevSpecialDown = specialDown;
+    this._prevJumpDown = jumpDown;
+    this._prevBlockDown = blockDown;
   }
 
   /**


### PR DESCRIPTION
## Problem

The keyboard action keys (`attackKey`/Space, `blockKey`/Shift, `keyW`, `keyQ`, …) were created in `create()` but **never bound to a listener and never polled**. `processKeyboardInput()` only handled left/right movement, so on desktop a player could walk but could **not attack, block, jump, or use specials** — the `handleAttack`/`handleBlock`/`handleSpecial`/`handleJumpDown` handlers were only reachable from the on-screen touch buttons.

## Fix

Add `handleKeyboardActions()`, called from `update()`, that polls the action keys and dispatches to the existing handlers:

- **attack** (Space), **special** (Q), **jump** (ArrowUp / W) are **edge-triggered** — a held key fires once per press;
- **block** (Shift) is a **held state** — engaged on press, released on key-up.

Edge detection uses tracked previous-frame key state rather than the Phaser keyboard plugin, so the method is unit-testable with mocked keys (unlike `processKeyboardInput`, which is gated behind a `jest` guard).

## Testing

- New `keyboard_actions.test.ts`: edge-triggering, jump keys, block press/release, game-over guard (5 tests).
- **Full suite still green: 785 tests / 105 suites** (plus the new suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized input wiring to existing combat handlers with regression tests; no auth, data, or architectural changes beyond per-frame key polling in the fight scene.
> 
> **Overview**
> Fixes a **desktop gameplay bug** where action keys were created in `create()` but never polled, so players could move but not attack, jump, block, or use specials.
> 
> Adds **`handleKeyboardActions()`**, invoked from **`update()`** after movement input, which reads Space/attack, Q/special, ArrowUp/W/jump, and Shift/block and forwards to the same **`handleAttack`**, **`handleSpecial`**, **`handleJumpDown`**, and **`handleBlock`** paths as the touch UI. Attack, special, and jump use **edge detection** via previous-frame key state so a held key fires once per press; block stays **held** until key-up, including clearing blocking state and sending an online **`block`** message with `active: false` on release.
> 
> Adds **`keyboard_actions.test.ts`** with mocked keys to cover edge-triggering, jump keys, block press/release, and the game-over guard (without relying on the Jest skip in **`processKeyboardInput`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 543efe96e792d76b969c950fa6470db5fdc5fbc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->