### PR TITLE
Remove dead health-broadcast calling non-existent wsManager.sendMessage

### DIFF
--- a/kidsfight_scene.ts
+++ b/kidsfight_scene.ts
@@ -1715,14 +1715,9 @@ export default class KidsFightScene extends Phaser.Scene {
     this.playerHealth[defenderIdxComputed] = Math.max(0, (this.playerHealth[defenderIdxComputed] || 0) - damage);
     defender.health = this.playerHealth[defenderIdxComputed];
 
-    // Send health update in online mode
-    if (this.gameMode === 'online' && this.wsManager && this.wsManager.sendMessage) {
-      this.wsManager.sendMessage({
-        type: 'health_update',
-        playerIndex: defenderIdxComputed,
-        health: this.playerHealth[defenderIdxComputed]
-      });
-    }
+    // (Health is broadcast below via wsManager.sendHealthUpdate for the local
+    // attacker. A dead block that called the non-existent wsManager.sendMessage
+    // used to sit here — removed.)
 
     // Update health bar visually
     this.updateHealthBar?.(defenderIdxComputed);


### PR DESCRIPTION
## Problem

`tryAttack` had an online health-broadcast guarded by `this.wsManager.sendMessage`:

```ts
if (this.gameMode === 'online' && this.wsManager && this.wsManager.sendMessage) {
  this.wsManager.sendMessage({ type: 'health_update', ... });
}
```

`WebSocketManager` has **no `sendMessage` method** (only `send`, `sendHealthUpdate`, `sendGameAction`, …), so the guard was always falsy and the block never ran. The real health broadcast happens a few lines later via `sendHealthUpdate`.

The dead code was misleading — it read like the authoritative health-sync path — and a latent trap: "fixing" the guard to `send` would have made every online hit **double-broadcast** health.

## Fix

Remove the dead block.

## Testing

Health/attack suites pass (`special_attack_z_index`, `online_health_sync`, `damage_calculation`, `kidsfight_scene_health_and_attack_logic` — 35 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal with no runtime behavior change; online health sync still uses sendHealthUpdate.
> 
> **Overview**
> Removes a misleading **online health sync block** in `tryAttack` that gated on `wsManager.sendMessage` and emitted a `health_update` payload.
> 
> `WebSocketManager` never implemented `sendMessage`, so that branch never ran; **online health is still sent** later in the same method via `sendHealthUpdate` when the local attacker lands a hit. The change is documentation-only in behavior but avoids a trap where “fixing” the guard could **double-broadcast** health.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac9a51b20582c710edab5c775c664b5473571410. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->