### PR TITLE
Drop unused gameUtils.tryAttack import; mark the helper deprecated

### DIFF
--- a/gameUtils.ts
+++ b/gameUtils.ts
@@ -297,6 +297,13 @@ interface AttackOptions {
 }
 
 // Function to try an attack
+/**
+ * @deprecated Not used by the game. KidsFightScene implements combat in its own
+ * `tryAttack` method (5/10 damage, 0-3 special-pip model). This standalone
+ * helper encodes an obsolete model (10/30 damage, 0-100 special meter) and is
+ * kept only for its existing unit tests. Do not treat it as the live combat
+ * logic, and do not import it into the scene.
+ */
 export function tryAttack({
   scene,
   attackerIdx,

--- a/kidsfight_scene.ts
+++ b/kidsfight_scene.ts
@@ -11,7 +11,6 @@ import player7RawImg from './sprites-jacqueline3.png';
 import player8RawImg from './sprites-ivan3.png';
 import player9RawImg from './sprites-d_isa.png';
 import { WebSocketManager } from './websocket_manager'; // This is a singleton instance, not a class
-import { tryAttack } from './gameUtils';
 import { time } from 'console';
 import { SCENARIOS } from './scenario_select_scene';
 const getCharacterName = 'getCharacterName';


### PR DESCRIPTION
## Problem

`KidsFightScene` imported `{ tryAttack } from './gameUtils'` but **never used it** — all combat runs through the scene's own `tryAttack` method. The standalone `gameUtils.tryAttack` encodes an **obsolete combat model** (10/30 damage, 0–100 special meter) that diverges from the live **5/10 damage, 0–3 pip** system, so it's a trap for anyone reading it as the real logic.

## Fix

- Remove the unused import from `kidsfight_scene.ts`.
- Add a `@deprecated` doc comment to `gameUtils.tryAttack` (kept only for its existing unit tests) warning against importing it into the scene.

Deleting the helper outright was avoided because `gameUtils.test.mjs` / `attackCooldown.test.mjs` still exercise it; that cleanup belongs with the dead-file removal.

## Testing

`gameUtils` + `damage_calculation` suites pass (24 tests); `tsc` shows no new errors from the removed import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime combat or import-path changes beyond removing dead code and comments; behavior stays on `KidsFightScene.tryAttack`.
> 
> **Overview**
> Removes an **unused** `tryAttack` import from `kidsfight_scene.ts` so the fight scene no longer suggests shared combat utilities drive gameplay—combat already runs through the scene’s own `tryAttack` method.
> 
> Adds a **`@deprecated` JSDoc** on `gameUtils.tryAttack` stating it is not live logic (obsolete 10/30 damage and 0–100 special meter vs the scene’s 5/10 and 0–3 pips), that it remains only for existing unit tests, and that it should not be wired into the scene.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 059121457c6f154be92a7102bffe5cbbe91dccea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->