### PR TITLE
Deliver a consistent parsed message shape from WebSocketManager

### DIFF
--- a/__tests__/websocket_manager.test.ts
+++ b/__tests__/websocket_manager.test.ts
@@ -248,10 +248,12 @@ describe('WebSocketManager', () => {
     console.log('Registering messageHandler1', handler1);
     wsManager.setMessageCallback(handler1);
 
-    // Trigger a message event with a JSON string, as a real WebSocket would
+    // Trigger a message event with a JSON string, as a real WebSocket would.
+    // The manager parses string data and delivers a consistent { data: <parsed> }
+    // shape regardless of when the callback was registered.
     (wsManager._ws as any)._trigger('message', { data: JSON.stringify(testData) });
-    // Assert handler1 is called
-    expect(messageHandler1).toHaveBeenCalledWith(JSON.stringify(testData));
+    // Assert handler1 is called with the parsed payload
+    expect(messageHandler1).toHaveBeenCalledWith(testData);
     expect(messageHandler2).not.toHaveBeenCalled();
     messageHandler1.mockClear();
 
@@ -265,7 +267,8 @@ describe('WebSocketManager', () => {
     console.log('Registering messageHandler2');
     const handler2 = (event: any) => {
       console.log('messageHandler2 called');
-      messageHandler2(JSON.parse(event.data));
+      // event.data is already parsed by the manager
+      messageHandler2(event.data);
     };
     wsManager.setMessageCallback(handler2);
 

--- a/websocket_manager.ts
+++ b/websocket_manager.ts
@@ -119,25 +119,7 @@ class WebSocketManager {
           console.log(`[WSM] Connected to server [${this._debugInstanceId}]`);
           this._onConnectionCallback?.(true);
           if (this._onMessageCallback) {
-            this._boundMessageCallback = (e: MessageEvent) => {
-              console.warn(`[WSM] _boundMessageCallback (connect) INVOKED. Current callback ID: ${this._currentCallbackId}`);
-              console.log('[WSM] Raw message event:', e.data);
-              try {
-                // Parse the message data if it's a string
-                let parsedData = e.data;
-                if (typeof e.data === 'string') {
-                  try {
-                    parsedData = JSON.parse(e.data);
-                  } catch (parseError) {
-                    // If it's not JSON, keep it as is
-                    parsedData = e.data;
-                  }
-                }
-                this._onMessageCallback?.({ ...e, data: parsedData });
-              } catch (error) {
-                console.error('[WSM] Error processing message:', error);
-              }
-            };
+            this._boundMessageCallback = this._makeMessageHandler();
             this._ws?.addEventListener('message', this._boundMessageCallback);
             console.log('[WSM] Message event listener registered', { ws: !!this._ws, callback: !!this._boundMessageCallback });
           }
@@ -281,6 +263,34 @@ class WebSocketManager {
     }
   }
 
+  /**
+   * Build the 'message' listener used everywhere we deliver messages to
+   * `_onMessageCallback`. It always JSON-parses a string `data` and delivers a
+   * consistent `{ ...event, data: <parsed> }` shape, regardless of whether the
+   * callback was registered before or after the socket opened. Previously the
+   * pre-open (connect) path parsed while the post-open paths delivered the raw
+   * event, so consumers received a parsed object or a raw JSON string depending
+   * purely on connection timing.
+   */
+  private _makeMessageHandler(): (event: MessageEvent) => void {
+    return (e: MessageEvent) => {
+      try {
+        let parsedData: any = e.data;
+        if (typeof e.data === 'string') {
+          try {
+            parsedData = JSON.parse(e.data);
+          } catch {
+            // Not JSON — keep the raw string.
+            parsedData = e.data;
+          }
+        }
+        this._onMessageCallback?.({ ...e, data: parsedData } as MessageEvent);
+      } catch (error) {
+        console.error('[WSM] Error processing message:', error);
+      }
+    };
+  }
+
   public onMessage(callback: (event: MessageEvent) => void): void {
     this._messageCallbackId++;
     const cbId = this._messageCallbackId;
@@ -296,7 +306,7 @@ class WebSocketManager {
 
     // If WebSocket is already connected, set up the new listener
     if (this.isConnected()) {
-      this._boundMessageCallback = (e: MessageEvent) => this._onMessageCallback?.(e);
+      this._boundMessageCallback = this._makeMessageHandler();
       this._ws!.addEventListener('message', this._boundMessageCallback);
     }
   }
@@ -307,7 +317,7 @@ class WebSocketManager {
       if (this._boundMessageCallback) {
         this._ws.removeEventListener('message', this._boundMessageCallback);
       }
-      this._boundMessageCallback = (e: MessageEvent) => this._onMessageCallback?.(e);
+      this._boundMessageCallback = this._makeMessageHandler();
       this._ws.addEventListener('message', this._boundMessageCallback);
     }
   }


### PR DESCRIPTION
## Problem

Message delivery depended on **connection timing**:

- A callback registered **before** the socket opened got the `connect()` onopen wrapper, which JSON-parses string data and delivers `{ ...event, data: <parsed> }`.
- A callback registered **after** the socket was already open (`onMessage` / `setMessageCallback`) got a raw listener that passed the untouched `MessageEvent` with an **unparsed JSON string**.

`KidsFightScene` registers post-connect (raw string) while `OnlineModeScene` registers pre-connect (parsed object). Every consumer had to defensively re-parse, and the single shared `_onMessageCallback` slot made this fragile — the root of the historical "callback conflict / player-selection sync" issues.

## Fix

Extract one `_makeMessageHandler()` that always parses string data and always delivers the same `{ ...event, data: <parsed> }` shape, and use it in all three registration paths (onopen, `onMessage`, `setMessageCallback`).

Updated the multi-callback test that asserted the old raw-string delivery (it even demonstrated the inconsistency — one handler read `event.data` raw, the other did `JSON.parse(event.data)`).

## Testing

- All websocket/online suites pass (111 tests).
- **Full suite: 785 tests / 105 suites pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the runtime contract for all online WebSocket consumers; misaligned handlers that always `JSON.parse(event.data)` could behave differently, though the intent is to fix timing-dependent sync bugs.
> 
> **Overview**
> **WebSocket message callbacks now always receive parsed JSON in `event.data`**, no matter whether the handler was registered before `connect()`’s `onopen` or later via `onMessage` / `setMessageCallback`.
> 
> The PR adds **`_makeMessageHandler()`** and routes all three registration paths through it, replacing the split where only the pre-open path parsed strings and post-open paths forwarded the raw `MessageEvent`. Non-JSON string payloads are left as-is.
> 
> Tests in **`websocket_manager.test.ts`** were updated so multi-callback coverage expects **parsed objects** (and handlers no longer call `JSON.parse` themselves), matching the new contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdbce10e4613c12635e01e147efd926d713b1540. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->