### PR TITLE
Remove dead local-mode button handlers in ScenarioSelectScene

### DIFF
--- a/scenario_select_scene.ts
+++ b/scenario_select_scene.ts
@@ -479,11 +479,6 @@ class ScenarioSelectScene extends Phaser.Scene {
       }
     );
   
-  // Local mode button handlers
-  if (this.mode === 'local') {
-      this.readyButton.on('pointerdown', () => this.startGame());
-      this.backButton.on('pointerdown', () => this.scene.start('MainMenuScene'));
-    }
   }
 
   private changeScenario(direction: number): void {


### PR DESCRIPTION
## Problem

A local-mode block re-bound `pointerdown` on both buttons on top of the primary handlers set a few lines earlier:

```ts
if (this.mode === 'local') {
  this.readyButton.on('pointerdown', () => this.startGame());
  this.backButton.on('pointerdown', () => this.scene.start('MainMenuScene'));
}
```

- `readyButton` already calls `startGame()` in local mode → this fired `startGame()` **twice** per tap.
- `backButton` already navigates to `PlayerSelectScene` → this also called `scene.start('MainMenuScene')`, a scene that is **never registered**, producing a Phaser warning / no-op.

## Fix

Remove the redundant block; the unconditional handlers already cover local mode.

## Testing

Scenario-select suites pass (55 tests); no new `tsc` errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small deletion of dead/duplicate UI wiring with no auth or data changes; local scenario-select navigation only.
> 
> **Overview**
> Removes a **local-mode-only** block in `ScenarioSelectScene` that registered a second `pointerdown` on **COMEÇAR** and **VOLTAR** after `createActionButtons()` already wired those buttons.
> 
> In local play, that duplication meant **`startGame()` ran twice** on each start tap, and **back** tried to open **`MainMenuScene`** (not registered) instead of relying on the existing **`PlayerSelectScene`** navigation. Behavior now comes only from the primary handlers in `createActionButtons()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7fec09a713d7422a7496412c120d268d380d43f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->