### PR TITLE
Honor selection direction in online character select

### DIFF
--- a/__tests__/player_selection_behaviour.test.ts
+++ b/__tests__/player_selection_behaviour.test.ts
@@ -399,6 +399,35 @@ describe('Player Selection Behaviour', () => {
       expect(scene.selected.p1).toBe('bento');
     });
 
+    it('should honor the direction argument in online mode (move backward)', () => {
+      scene.init({ mode: 'online' });
+      scene.backButton = new MockText();
+      scene.create();
+      scene.CHARACTER_KEYS = [
+        'bento', 'davir', 'jose', 'davis',
+        'carol', 'roni', 'jacqueline', 'ivan', 'd_isa'
+      ];
+      scene.characters = scene.CHARACTER_KEYS.map((key: string, i: number) => ({ key, name: key, x: i, y: 0, scale: 1 }));
+      scene.characterSprites = {};
+      for (const char of scene.characters) {
+        scene.characterSprites[char.key] = new MockSprite(scene, 0, 0, char.key);
+        patchCharacterSpriteOn(scene, char.key);
+      }
+      scene.isHost = true;
+
+      // Moving left from index 1 should land on index 0, not advance to 2.
+      scene.p1Index = 1;
+      scene.selected = { p1: '', p2: '' };
+      scene.handleCharacterSelect(1, -1);
+      expect(scene.p1Index).toBe(0);
+      expect(scene.selected.p1).toBe('bento');
+
+      // Moving left from index 0 should wrap around to the last character.
+      scene.handleCharacterSelect(1, -1);
+      expect(scene.p1Index).toBe(scene.CHARACTER_KEYS.length - 1);
+      expect(scene.selected.p1).toBe('d_isa');
+    });
+
     it('should send player selection to WebSocket in online mode', () => {
       // Create a new scene with proper type assertions and mock WebSocketManager
       const wsScene = new PlayerSelectScene(mockWebSocketManager as unknown as WebSocketManager) as unknown as PlayerSelectSceneWithWS;

--- a/player_select_scene.ts
+++ b/player_select_scene.ts
@@ -427,15 +427,15 @@ export default class PlayerSelectScene extends Phaser.Scene {
       this.updateSelectionIndicators();
       this.updateReadyUI();
     } else {
-      // Online mode: only allow the local player to move their selector
+      // Online mode: only allow the local player to move their selector.
+      // Use the direction-aware newIndex computed above; recomputing it as
+      // (index + 1) made both left and right advance the selector forward.
       if ((player === 1 && this.isHost) || (player === 2 && !this.isHost)) {
         if (player === 1) {
-          newIndex = (this.p1Index + 1) % this.CHARACTER_KEYS.length;
           this.p1Index = newIndex;
           this.selected.p1 = this.characters[newIndex].key;
           this.selectedP1Index = newIndex;
         } else {
-          newIndex = (this.p2Index + 1) % this.CHARACTER_KEYS.length;
           this.p2Index = newIndex;
           this.selected.p2 = this.characters[newIndex].key;
           this.selectedP2Index = newIndex;


### PR DESCRIPTION
## Problem

`handleCharacterSelect(player, direction)` computed a direction-aware index at the top:

```ts
let newIndex = (currentIndex + direction + this.CHARACTER_KEYS.length) % this.CHARACTER_KEYS.length;
```

…but the **online** branch discarded it and recomputed `newIndex = (this.p1Index + 1) % len`. So in online mode pressing **left and right both advanced the selector forward** — you could never move backward through the roster.

## Fix

Drop the `(index + 1)` recomputation and use the direction-aware `newIndex`.

## Testing

- New regression test moves the selector backward (index 1 → 0) and wraps (0 → last) in online mode.
- Player-select suites pass (81 tests + the new case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI fix in player select with test coverage; no auth, data, or networking protocol changes beyond sending the correct character after navigation.
> 
> **Overview**
> **Online character select** no longer ignores left/right input: the online branch in `handleCharacterSelect` now applies the same direction-aware `newIndex` as local mode instead of always advancing with `(index + 1)`.
> 
> Hosts and guests can move backward through the roster and wrap at the ends when cycling with `direction` **-1** or **1**. WebSocket `player_selected` payloads still use the resolved character key from that index.
> 
> A regression test covers backward steps (index 1 → 0) and wrap (0 → last) for the host in online mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35e9c792b7ba35eba01812ecaf1590ad10466caf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->