### PR TITLE
Make updateReadyUI update the ready button instead of no-op'ing

### DIFF
--- a/player_select_scene.ts
+++ b/player_select_scene.ts
@@ -721,19 +721,17 @@ export default class PlayerSelectScene extends Phaser.Scene {
   }
 
   private updateReadyUI(): void {
-    if (!this.player1ReadyText || !this.player2ReadyText) return;
-
-    this.player1ReadyText.setText(`P1 ${this.player1Ready ? 'Ready' : 'Not Ready'}`);
-    this.player2ReadyText.setText(`P2 ${this.player2Ready ? 'Ready' : 'Not Ready'}`);
-
-    if (this.readyButton) {
-      const isReady = this.isHost ? this.player1Ready : this.player2Ready;
-      this.readyButton.setText(isReady ? 'Cancelar' : 'COMEÇAR');
-      this.readyButton.setStyle({
-        color: '#fff',
-        backgroundColor: isReady ? '#ff4444' : '#4CAF50'
-      });
+    // The optional per-player "ready" text labels are not always created, so
+    // update them only when present...
+    if (this.player1ReadyText && this.player2ReadyText) {
+      this.player1ReadyText.setText(`P1 ${this.player1Ready ? 'Ready' : 'Not Ready'}`);
+      this.player2ReadyText.setText(`P2 ${this.player2Ready ? 'Ready' : 'Not Ready'}`);
     }
+    // ...but always keep the ready button in sync. Previously this method
+    // early-returned when the (never-created) labels were missing, so the
+    // ready button never updated. Delegate to the canonical helper instead of
+    // duplicating its styling with different colors/casing.
+    this.updateReadyButton();
   }
 
   private createSelectionIndicators(): void {


### PR DESCRIPTION
## Problem

`updateReadyUI` began with:

```ts
if (!this.player1ReadyText || !this.player2ReadyText) return;
```

…but `player1ReadyText` / `player2ReadyText` are **never created**, so the method always early-returned. Every caller (character select, ready toggle, remote ready-state sync) silently did nothing, and the ready button never reflected ready/cancel state through this path. It also duplicated `updateReadyButton` with **divergent styling** (`#ff4444` / `'Cancelar'` vs the canonical `#AA0000` / `'CANCELAR'`).

## Fix

Guard the optional text labels (update them only if present) but always delegate the button update to the canonical `updateReadyButton()` helper — no caller changes, single source of truth for the button styling.

## Testing

Player-select + ready-button + sync suites pass (113 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-method UI sync fix in player select; no API or networking changes, with existing tests covering the flow.
> 
> **Overview**
> **`updateReadyUI` no longer no-ops** when the per-player ready text objects are absent. Those labels are declared but never instantiated, so the old guard always returned early and paths that call `updateReadyUI` (character select, remote `playerReady` sync) never refreshed the ready button.
> 
> The method now updates P1/P2 ready text only if both labels exist, and **always** calls **`updateReadyButton()`** so label text, colors (`#00AA00` / `#AA0000`), and **COMEÇAR** / **CANCELAR** stay consistent with the rest of the scene instead of duplicating divergent styling in `updateReadyUI`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7395d7a34b00e9b5ddaa510d5677f656b9719936. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->