### PR TITLE
Remove stray Node 'console' import and dead getCharacterName const

### DIFF
--- a/kidsfight_scene.ts
+++ b/kidsfight_scene.ts
@@ -12,9 +12,7 @@ import player7RawImg from './sprites-jacqueline3.png';
 import player8RawImg from './sprites-ivan3.png';
 import player9RawImg from './sprites-d_isa.png';
 import { WebSocketManager } from './websocket_manager'; // This is a singleton instance, not a class
-import { time } from 'console';
 import { SCENARIOS } from './scenario_select_scene';
-const getCharacterName = 'getCharacterName';
 
 interface PlayerProps {
   isAttacking: boolean;


### PR DESCRIPTION
## Problem

`kidsfight_scene.ts` had two pieces of dead top-level code:

- `import { time } from 'console';` — a **Node.js builtin** that has no place in a Phaser/browser bundle and was never used (the game uses `this.time`, Phaser's clock, not the bare `time`).
- `const getCharacterName = 'getCharacterName';` — an unused module-level string that shadowed the name of the `getCharacterName` **method** (all real uses are `this.getCharacterName`).

## Fix

Remove both.

## Testing

Smoke suites pass (`kidsfight_scene`, `damage_calculation`); grep confirms no remaining references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only cleanup with no logic changes; low risk to runtime behavior.
> 
> **Overview**
> Removes two unused top-level lines from `kidsfight_scene.ts`: a Node `console` import that does not belong in the browser/Phaser bundle, and a module-level `getCharacterName` string that was never referenced (character names still come from the private `getCharacterName` method via `this.getCharacterName`).
> 
> No gameplay or API behavior changes—cleanup only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f1fbea312ab7b11c7b290ffe0c4535a21aa5428. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->