### PR TITLE
Add missing createAttackEffect so regular attacks show a visual

### DIFF
--- a/kidsfight_scene.ts
+++ b/kidsfight_scene.ts
@@ -2378,6 +2378,40 @@ export default class KidsFightScene extends Phaser.Scene {
     }
   }
 
+  /**
+   * Small burst shown for a regular (non-special) attack. Previously the code
+   * called this.createAttackEffect for normal attacks, but the method never
+   * existed, so regular attacks had no attack visual (only the hit effect).
+   */
+  public createAttackEffect(attacker: any, defender: any): void {
+    try {
+      const isTest = typeof jest !== 'undefined';
+      // Burst near the point of contact, biased toward the defender.
+      const x = (attacker.x + defender.x) / 2;
+      const y = (attacker.y + defender.y) / 2 - 30;
+      const graphicsObj = this.add.graphics();
+      graphicsObj.fillStyle(0xffdd33, 0.7); // Warm yellow
+      graphicsObj.fillCircle(x, y, 22);
+      graphicsObj.fillStyle(0xffffff, 0.35); // Soft glow
+      graphicsObj.fillCircle(x, y, 32);
+      graphicsObj.setDepth(1000);
+      if (!isTest) {
+        console.log('Attack effect created at', x, y);
+      }
+      if (!this.hitEffects) this.hitEffects = [];
+      this.hitEffects.push(graphicsObj);
+      if (this.time && typeof this.time.delayedCall === 'function') {
+        this.time.delayedCall(200, () => {
+          const idx = this.hitEffects.indexOf(graphicsObj);
+          if (idx !== -1) this.hitEffects.splice(idx, 1);
+          if (typeof graphicsObj.destroy === 'function') graphicsObj.destroy();
+        });
+      }
+    } catch (error: any) {
+      console.error('Error creating attack effect:', error);
+    }
+  }
+
   // ------------------------------------------------------------------
   // Game loop
   // ------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The attack path called `this.createAttackEffect(attacker, defender)` for non-special hits:

```ts
} else if (!special && typeof this.createAttackEffect === 'function') {
  this.createAttackEffect(attacker, defender);
}
```

…but `createAttackEffect` was **never defined** — only `createSpecialAttackEffect` and `createHitEffect` exist. Because the call is guarded by a `typeof … === 'function'` check it silently no-op'd, so **regular attacks produced no attack burst** (only the hit effect). `tsc` flagged the call too (TS2551 "Did you mean createHitEffect?").

## Fix

Implement `createAttackEffect` as a small warm-yellow burst near the point of contact, mirroring `createSpecialAttackEffect`'s lifecycle (tracked in `hitEffects`, auto-destroyed via `time.delayedCall`).

## Testing

- The TS2551 errors on the call site are gone.
- Attack/effect/special suites pass (97 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely cosmetic Phaser graphics with the same cleanup pattern as other effects; no combat, networking, or persistence changes.
> 
> **Overview**
> Adds the missing **`createAttackEffect`** method on `KidsFightScene` so non-special hits can show an attack burst, not only the defender hit flash.
> 
> `tryAttack` already called `createAttackEffect` behind a `typeof … === 'function'` guard, but the method did not exist, so regular attacks were silent visually and TypeScript reported **TS2551**. The new implementation draws a warm-yellow double-circle burst midway between attacker and defender, pushes it onto **`hitEffects`**, sets depth **1000**, and removes it after **200ms** via **`time.delayedCall`**, matching the lifecycle pattern used by **`createSpecialAttackEffect`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9143e73c04fcc1902da17acc235235d175257ab8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->