### PR TITLE
Use a consistent jump velocity across all paths

### DIFF
--- a/__tests__/kidsfight_scene.test.ts
+++ b/__tests__/kidsfight_scene.test.ts
@@ -638,7 +638,7 @@ describe('KidsFightScene', () => {
       player1.body.onFloor.mockReturnValueOnce(true);
       const jumpAction = {type: 'jump', playerIndex: 0};
       scene.handleRemoteAction(jumpAction);
-      expect(player1.setVelocityY).toHaveBeenCalledWith(-500);
+      expect(player1.setVelocityY).toHaveBeenCalledWith(-330);
     });
 
     it('should handle player attack', () => {

--- a/kidsfight_scene.ts
+++ b/kidsfight_scene.ts
@@ -1931,9 +1931,10 @@ export default class KidsFightScene extends Phaser.Scene {
         break;
       }
       case 'jump': {
-        const isOnlineGame = ((this as any).isOnline ?? false) || this.gameMode === 'online';
-        const jumpVel = isOnlineGame ? -330 : -500;
-        player.setVelocityY?.(jumpVel);
+        // Use the same jump velocity as every other jump path (touch, keyboard,
+        // online). The old local-mode value (-500) made jump height depend on
+        // the code path.
+        player.setVelocityY?.(-330);
         break;
       }
       case 'block': {


### PR DESCRIPTION
## Problem

`handleRemoteAction`'s `jump` case set velocity to `-330` online but `-500` in local mode:

```ts
const jumpVel = isOnlineGame ? -330 : -500;
```

Every other jump path — the touch jump button, keyboard jump, `handleJumpDown` — uses `-330`. So jump height depended on which code path handled the jump.

## Fix

Standardize the remote-action jump on `-330`, matching all other paths. Updated the one test that asserted the `-500` local value.

## Testing

`kidsfight_scene`, `handle_remote_action`, `kidsfight_scene_handle_remote_action` suites pass (33 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized gameplay physics change with no auth, networking protocol, or data handling impact.
> 
> **Overview**
> **Jump height is now consistent** when jumps are applied through `handleRemoteAction`: the `jump` case always sets vertical velocity to **`-330`**, instead of using **`-500` in local mode** and **`-330` online**.
> 
> That removes a mismatch with touch, keyboard, and `handleJumpDown`, which already used `-330`, so local play no longer got taller jumps when the remote-action path handled the jump. The remote jump unit test expectation was updated to **`-330`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48901e4fe491e8f34aef331d6e9ca322bf9089ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->