### PR TITLE
Guard updateSceneLayout health-bar math against missing players

### DIFF
--- a/gameUtils.ts
+++ b/gameUtils.ts
@@ -143,7 +143,7 @@ export function updateSceneLayout(scene: any): void {
     console.log('DEBUG:updateSceneLayout: healthBarBg2 or setPosition/setSize missing', scene.healthBarBg2);
   }
   
-  if (scene.healthBar1 && scene.healthBar1.setPosition && scene.healthBar1.setSize) {
+  if (scene.players?.[0] && scene.healthBar1 && scene.healthBar1.setPosition && scene.healthBar1.setSize) {
     console.log('DEBUG:updateSceneLayout: calling healthBar1.setPosition with', p1X - barWidth/2 + (barWidth * (scene.players[0].health || 0))/200, barY);
     scene.healthBar1.setPosition(p1X - barWidth/2 + (barWidth * (scene.players[0].health || 0))/200, barY);
     console.log('DEBUG:updateSceneLayout: calling healthBar1.setSize with', barWidth * (scene.players[0].health || 0)/100, barHeight);
@@ -152,7 +152,7 @@ export function updateSceneLayout(scene: any): void {
     console.log('DEBUG:updateSceneLayout: healthBar1 or setPosition/setSize missing', scene.healthBar1);
   }
   
-  if (scene.healthBar2 && scene.healthBar2.setPosition && scene.healthBar2.setSize) {
+  if (scene.players?.[1] && scene.healthBar2 && scene.healthBar2.setPosition && scene.healthBar2.setSize) {
     console.log('DEBUG:updateSceneLayout: calling healthBar2.setPosition with', p2X - barWidth/2 + (barWidth * (scene.players[1].health || 0))/200, barY);
     scene.healthBar2.setPosition(p2X - barWidth/2 + (barWidth * (scene.players[1].health || 0))/200, barY);
     console.log('DEBUG:updateSceneLayout: calling healthBar2.setSize with', barWidth * (scene.players[1].health || 0)/100, barHeight);


### PR DESCRIPTION
## Problem

In `gameUtils.updateSceneLayout`, the health-bar positioning reads `scene.players[0].health` / `scene.players[1].health`, but the surrounding guards only check that `healthBar1` / `healthBar2` exist — not the player objects. If the bars exist before `players` is populated, the function throws a `TypeError`.

## Fix

Add `scene.players?.[0]` / `scene.players?.[1]` to the respective guards.

## Testing

gameUtils/layout suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow defensive guard change in UI layout only; behavior when players exist is unchanged.
> 
> **Overview**
> **`updateSceneLayout`** in `gameUtils.ts` could throw when **`healthBar1`** / **`healthBar2`** exist but **`scene.players`** is not yet populated, because fill math reads **`scene.players[0].health`** and **`scene.players[1].health`**.
> 
> The change adds **`scene.players?.[0]`** and **`scene.players?.[1]`** to those blocks’ guards so layout skips health-bar updates until the corresponding player entry exists, matching how player positioning is already guarded earlier in the same function.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89418291c6584e0957476a8c865f18227c4e1bc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->