### PR TITLE
Align d_isa battle-HUD name with the selection screen

### DIFF
--- a/kidsfight_scene.ts
+++ b/kidsfight_scene.ts
@@ -965,7 +965,7 @@ export default class KidsFightScene extends Phaser.Scene {
       'roni': 'Roni',
       'jacqueline': 'Jacqueline',
       'ivan': 'Ivan',
-      'd_isa': 'D\'Isa',
+      'd_isa': 'D. Isa',
       'player1': 'Bento',
       'player2': 'Davi R'
     };


### PR DESCRIPTION
## Problem

`getCharacterName` rendered `d_isa` as **"D'Isa"** in the battle HUD, while the character-select screen renders it as **"D. Isa"** — the same fighter shown under two different names. (An existing `getDisplayName` test also expects `"D. Isa"`.)

## Fix

Use `"D. Isa"` in the HUD map, matching the selection screen and the existing test expectation.

## Testing

Game-state / name suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single string change in a display-name map with no gameplay or data impact.
> 
> **Overview**
> Updates the **`d_isa`** entry in `getCharacterName` so the battle HUD shows **"D. Isa"** instead of **"D'Isa"**.
> 
> That label is used for win/time-up messages and other in-fight UI that resolves names from texture keys, so the fighter now matches the character-select screen and existing display-name test expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad3aa328342e2ad4313967df878edd52ec85bfd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->