### PR TITLE
Stop treating the real character 'davir' as a selection sentinel

### DIFF
--- a/scenario_select_scene.ts
+++ b/scenario_select_scene.ts
@@ -124,7 +124,10 @@ class ScenarioSelectScene extends Phaser.Scene {
         }, 50);
       } else {
         // Guest only re-sends their own selection (p2) if it's not a default/invalid value
-        if (this.selected.p2 && this.selected.p2 !== 'davir' && this.selected.p2 !== 'player2') {
+        // 'player2' is the placeholder default; skip only that (and empty).
+        // 'davir' is a real, selectable character and must NOT be treated as a
+        // sentinel, or a guest who picks Davi R never syncs their choice.
+        if (this.selected.p2 && this.selected.p2 !== 'player2') {
           console.log('[ScenarioSelectScene] Guest re-sending p2 character selection:', { 
             p2: this.selected.p2 
           });


### PR DESCRIPTION
## Problem

On entering `ScenarioSelectScene`, a guest re-sends their p2 selection unless it's a default/placeholder:

```ts
if (this.selected.p2 && this.selected.p2 !== 'davir' && this.selected.p2 !== 'player2') {
```

`'player2'` is the actual placeholder default, but `'davir'` (Davi R) is a **real, selectable character**. A guest who genuinely picked Davi R had their selection **skipped**, so the host never received it and the roster desynced.

## Fix

Skip only the `'player2'` placeholder (and empty).

## Testing

Scenario-select suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional change in online guest character re-sync; no auth or broader flow changes.
> 
> **Overview**
> Fixes **online roster desync** when a guest picks **Davi R** (`davir`).
> 
> On `ScenarioSelectScene` entry, guests re-send their p2 `player_selected` over WebSocket unless the value is still a placeholder. The guard incorrectly treated **`davir` like a sentinel** alongside **`player2`**, so a real Davi R choice was **never re-sent** and the host could miss the guest’s character.
> 
> The condition now **skips only empty / `player2`**, with comments clarifying that **`davir` is a valid selectable key** (aligned with `_transitionToGame`’s `validKeys`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eeb4220a5e57fe942af2ffffd360ed1f08d86a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->