### PR TITLE
Draw the rotate-prompt icon instead of loading a missing texture

### DIFF
--- a/rotate_prompt_scene.ts
+++ b/rotate_prompt_scene.ts
@@ -8,7 +8,7 @@ import KidsFightScene from './kidsfight_scene';
 class RotatePromptScene extends Phaser.Scene {
   private bg!: Phaser.GameObjects.Rectangle;
   private text!: Phaser.GameObjects.Text;
-  private icon!: Phaser.GameObjects.Image;
+  private icon!: Phaser.GameObjects.Text;
   private scenesAdded: boolean;
 
   constructor() {
@@ -30,9 +30,13 @@ class RotatePromptScene extends Phaser.Scene {
       wordWrap: { width: w * 0.8 }
     }).setOrigin(0.5);
     
-    this.icon = this.add.image(w/2, h/2 - 80, 'rotate_icon')
-      .setOrigin(0.5)
-      .setScale(0.5);
+    // Drawn glyph instead of a 'rotate_icon' image that was never preloaded
+    // (there is no such asset), which rendered as a missing-texture box.
+    this.icon = this.add.text(w/2, h/2 - 80, '↻️', {
+      fontSize: `${Math.max(48, Math.round(w * 0.1))}px`,
+      color: '#fff',
+      fontFamily: 'monospace'
+    }).setOrigin(0.5);
   }
 
   resize(): void {


### PR DESCRIPTION
## Problem

`RotatePromptScene` added an image with texture key `'rotate_icon'`, but **no scene preloads that asset** (there's no `rotate_icon` file and the scene has no `preload`). On portrait/mobile — exactly where the "please rotate your device" prompt shows — this rendered a **missing-texture box**.

## Fix

Replace the image with a drawn text glyph so the prompt renders correctly without needing an asset. (`resize()` already repositions it via `setPosition`, which works on Text.)

## Testing

`orientationOverlay` suite passes; no `tsc` errors in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-scene UI fix with no asset pipeline, auth, or gameplay logic changes.
> 
> **Overview**
> Fixes the portrait **rotate device** overlay showing a **missing-texture box** by stopping use of the never-preloaded `'rotate_icon'` image.
> 
> The icon is now a **Phaser `Text`** glyph (`↻️`) with responsive font sizing; `resize()` still repositions it with `setPosition` (unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87af3e98cf75e7ee1e2299287ead5a11dbbb1200. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->