### PR TITLE
Normalize legacy player1/player2 keys to real sprites in the battle scene

### DIFF
--- a/kidsfight_scene.ts
+++ b/kidsfight_scene.ts
@@ -1021,8 +1021,16 @@ export default class KidsFightScene extends Phaser.Scene {
 
     // Determine scenario and player keys from selected data, with fallbacks
     const scenarioKey = (data && data.scenario) ? data.scenario : (this.selectedScenario || 'scenario1');
-    const p1Key = this.selected?.p1 || 'bento';
-    const p2Key = this.selected?.p2 || 'roni';
+    // Normalize legacy placeholder keys to real, loaded sprite keys. 'player1'
+    // and 'player2' are placeholders/aliases (see getCharacterName) with no
+    // sprite of their own, so using them directly rendered a missing texture.
+    const normalizeKey = (k: string | undefined, fallback: string): string => {
+      if (k === 'player1') return 'bento';
+      if (k === 'player2') return 'davir';
+      return k || fallback;
+    };
+    const p1Key = normalizeKey(this.selected?.p1, 'bento');
+    const p2Key = normalizeKey(this.selected?.p2, 'roni');
 
     // Render background
     const bg = this.safeAddImage(400, 240, scenarioKey);


### PR DESCRIPTION
## Problem

`'player1'` / `'player2'` are placeholder/alias keys (`getCharacterName` maps them to Bento / Davi R) that have **no sprite of their own**. They can reach `KidsFightScene` via the scenario-select fallback paths (which even list them in `validKeys`), and the scene passed the key straight to `physics.add.sprite(x, y, p1Key, 0)` — so a battle could start with **Phaser's missing-texture placeholder** instead of a fighter.

## Fix

Normalize `player1 → bento` and `player2 → davir` when resolving the sprite keys, matching the existing display-name aliasing. This fixes the render at the point where the texture is actually used, and is backward compatible with the many call sites and tests that pass `player1`/`player2` through.

## Testing

Scene / scenario / character suites pass (341 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single localized key-mapping at sprite creation; backward compatible with existing keys and tests that still pass `player1`/`player2`.
> 
> **Overview**
> **Fixes missing fighter textures** when the battle scene receives legacy `player1` / `player2` character keys from scenario-select fallbacks or defaults.
> 
> In `KidsFightScene.create()`, sprite keys are now passed through a **`normalizeKey`** helper before `physics.add.sprite`: `player1` → `bento`, `player2` → `davir`, with unchanged fallbacks for other keys (`bento` / `roni` when unset). Display-name aliasing in `getCharacterName` was already correct; this change applies the same mapping where Phaser actually loads textures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1cd3d3a421bcdf6d11207e906fbecaae31a2f2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->