### PR TITLE
Use ATTACK_DAMAGE/SPECIAL_DAMAGE constants in tryAttack

### DIFF
--- a/kidsfight_scene.ts
+++ b/kidsfight_scene.ts
@@ -1690,7 +1690,7 @@ export default class KidsFightScene extends Phaser.Scene {
     } else {
       defenderIdxComputed = attackerIdx === 0 ? 1 : 0;
     }
-    let damage = special ? 10 : 5;
+    let damage = special ? this.SPECIAL_DAMAGE : this.ATTACK_DAMAGE;
     const targetBlocking = this.playerBlocking?.[defenderIdxComputed] || defender.getData?.('isBlocking');
     if (targetBlocking) damage = Math.floor(damage / 2);
 


### PR DESCRIPTION
## Problem

`tryAttack` hardcoded `let damage = special ? 10 : 5;` while the class already declares `ATTACK_DAMAGE = 5` and `SPECIAL_DAMAGE = 10`. Editing those constants had **no effect** on actual damage — a tuning trap.

## Fix

Reference the constants (`special ? this.SPECIAL_DAMAGE : this.ATTACK_DAMAGE`). Values are unchanged, so behavior is identical; damage now has a single source of truth.

## Testing

Damage / attack / health / special suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line refactor in combat math with identical values; no auth, networking, or data-path changes.
> 
> **Overview**
> **`tryAttack`** no longer uses literal `5` / `10` for hit damage; it reads **`this.ATTACK_DAMAGE`** and **`this.SPECIAL_DAMAGE`**, which the scene already exposes for tests and tuning.
> 
> Numeric behavior is unchanged at the current constant values (5 normal, 10 special). Changing those fields now affects real combat instead of leaving a dead tuning path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19b5751df04fbad5de2fb92ad27bd2ed18acaf3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->