### PR TITLE
Fix duplicate resize listener and preview jump in ScenarioSelectScene

### DIFF
--- a/scenario_select_scene.ts
+++ b/scenario_select_scene.ts
@@ -354,9 +354,7 @@ class ScenarioSelectScene extends Phaser.Scene {
       };
       this.wsManager.setMessageCallback(this._wsMessageHandler);
     }
-
-    // Responsive layout update on resize
-    this.scale.on('resize', this.updateLayout, this);
+    // (resize handler is registered once earlier in create())
   }
 
   private createNavigationButtons(): void {
@@ -692,7 +690,8 @@ class ScenarioSelectScene extends Phaser.Scene {
 
     // Update positions of UI elements based on new size
     if (this.preview) {
-      this.preview.setPosition(width / 2, height / 2 - 50);
+      // Match the Y used in create() so the preview doesn't jump on resize.
+      this.preview.setPosition(width / 2, height / 2);
       this.rescalePreview();
     }
 


### PR DESCRIPTION
## Problem

Two issues in `ScenarioSelectScene`:

1. `create()` registered `this.scale.on('resize', this.updateLayout, this)` **twice**, so `updateLayout` ran twice per resize — while `shutdown()` removes it only once (a half-cleaned listener).
2. The scenario preview was centered at `height/2` in `create()` but moved to `height/2 - 50` in `updateLayout`, so it **jumped up 50px** after any resize/rotate.

## Fix

- Register the resize handler once.
- Use `height/2` for the preview in `updateLayout`, matching `create()`.

## Testing

Scenario-select suites pass (55 tests); grep confirms a single `resize` registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI/layout fix in scenario select; no auth, networking, or data-path changes beyond listener cleanup.
> 
> **Overview**
> **ScenarioSelectScene** no longer registers `scale.on('resize', updateLayout)` twice at the end of `create()`, so each resize runs layout once and `shutdown()`’s single `scale.off` fully removes the listener.
> 
> **`updateLayout`** now places the scenario preview at `height / 2`, matching `create()`, so the preview no longer jumps up 50px after resize or rotation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d5481a08437713c9012550019a8ba9297e437bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->