### PR TITLE
Stop connect() from clobbering the host flag

### DIFF
--- a/websocket_manager.ts
+++ b/websocket_manager.ts
@@ -124,7 +124,9 @@ class WebSocketManager {
 
     return new Promise((resolve, reject) => {
       try {
-        this._isHost = false;
+        // Don't reset the host flag here: connectAsHost() calls setHost(true)
+        // before connect(), so clearing it clobbered the host role on every
+        // fresh connection. setHost() is the sole authority for _isHost.
         // Connect to the resolved URL, not the raw (possibly undefined) argument.
         this._ws = this._webSocketFactory(wsUrl);
         console.log('[WSM][DIAG] _ws created', { ws: !!this._ws, url: this._ws?.url });


### PR DESCRIPTION
## Problem

`connect()` unconditionally did `this._isHost = false;`. But `connectAsHost()` calls `setHost(true)` **before** `connect()`:

```ts
this.wsManager.setHost(true);
const ws = await this.wsManager.connect(getWebSocketUrl(), roomCode);  // resets _isHost = false
```

So a host's flag was reset to `false` on every fresh connection, leaving the manager unaware it was the host.

## Fix

Don't touch `_isHost` in `connect()`. `setHost()` is the sole authority for the flag. (`connectAsClient` already calls `setHost(false)` explicitly, so nothing regresses for guests.)

## Testing

WebSocket + online-mode suites pass (88 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes online multiplayer host/client identity in WebSocketManager; wrong behavior could affect match authority, though the change is small and aligns with existing `setHost` usage.
> 
> **Overview**
> **Fixes online host role being lost on every new WebSocket connection.**
> 
> `connect()` no longer forces `_isHost = false`. The host flow in `connectAsHost()` calls `setHost(true)` and then `await connect()`, so resetting the flag inside `connect()` made the manager think it was always a client after connect. **`setHost()` is now the only place that sets `_isHost`**; guest paths that call `setHost(false)` before connect are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e1f1ee24d5d1c0132348789ae49bf61c0c7657b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->