### PR TITLE
Remove dead room_joined message branch

### DIFF
--- a/online_mode_scene.ts
+++ b/online_mode_scene.ts
@@ -348,18 +348,6 @@ export default class OnlineModeScene extends Phaser.Scene {
         this.wsManager.setRoomCode(data.roomCode);
         this.wsManager.setHost(true);
         this.showRoomCode(data.roomCode);
-      } else if (data.type === 'room_joined') {
-        // Don't reconnect if already connected
-        if (!this.wsManager.isConnected()) {
-          const ws = await this.wsManager.connect(getWebSocketUrl(), data.roomCode);
-          if (!ws) {
-            console.error('Failed to connect to WebSocket server');
-            return;
-          }
-        }
-        this.wsManager.setRoomCode(data.roomCode);
-        this.wsManager.setHost(false);
-        this.startGame({ roomCode: data.roomCode, isHost: false });
       } else if (data.type === 'player_joined') {
         console.log('Player joined, starting game...');
         this.wsManager.setRoomCode(data.roomCode); // Ensure roomCode is set


### PR DESCRIPTION
## Problem

`OnlineModeScene` handled a `'room_joined'` message type that the **server never sends** — `server/server.js` emits `room_created`, `player_joined`, and `game_joined` (the live join path). The branch was unreachable and misrepresented the protocol.

## Fix

Remove the dead branch.

## Testing

Online-mode suites pass; no test references `room_joined`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal only; live online join/start paths are unchanged and tests still pass.
> 
> **Overview**
> Removes the **`room_joined`** branch from `OnlineModeScene.handleWebSocketMessage`, which duplicated join-client logic (reconnect, `setRoomCode`, `setHost(false)`, `startGame`) but was never triggered because the server only emits **`room_created`**, **`player_joined`**, and **`game_joined`**.
> 
> Joining players continue to enter the game via the existing **`game_joined`** handler; host flow via **`room_created`** and **`player_joined`** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c3f79a3dd4166a7b7cd91813a9bc173febaec30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->