### PR TITLE
Destroy old objects on PlayerSelectScene re-layout to stop leaks

### DIFF
--- a/player_select_scene.ts
+++ b/player_select_scene.ts
@@ -296,6 +296,20 @@ export default class PlayerSelectScene extends Phaser.Scene {
   }
 
   private setupCharacters(): void {
+    // Destroy objects from a previous layout pass so a resize doesn't stack
+    // duplicate circles/sprites/labels (with live pointer handlers) on top of
+    // the old ones.
+    if (this.characters && this.characters.length) {
+      this.characters.forEach(c => {
+        c.bgCircle?.destroy?.();
+        c.nameLabel?.destroy?.();
+      });
+    }
+    if (this.characterSprites) {
+      Object.values(this.characterSprites).forEach(s => (s as any)?.destroy?.());
+      this.characterSprites = {};
+    }
+
     const w = this.cameras.main.width;
     const h = this.cameras.main.height;
     // --- Responsive character grid setup (centered grid, smaller height section) ---
@@ -761,6 +775,11 @@ export default class PlayerSelectScene extends Phaser.Scene {
   }
 
   private createUIButtons(): void {
+    // Destroy the previous buttons so a resize doesn't leave stale, still-
+    // clickable ready/back buttons stacked behind the new ones.
+    this.readyButton?.destroy?.();
+    this.backButton?.destroy?.();
+
     const w = this.cameras.main.width;
     const h = this.cameras.main.height;
 


### PR DESCRIPTION
## Problem

`updateLayout()` re-ran `setupCharacters()` and `createUIButtons()` on every resize **without destroying** the objects from the previous pass. Each resize (orientation change, mobile browser-chrome show/hide, window resize) stacked:

- 9 more background circles
- 9 more **interactive** character sprites
- 9 more name labels
- a fresh ready/back button pair

The stale sprites kept their `pointerdown` handlers and the stale ready button kept its `launchGame` handler, so **ghost hit-areas and buttons stayed clickable** at old positions — a memory leak *and* a correctness bug.

## Fix

- Destroy the prior character circles/sprites/labels at the top of `setupCharacters()`.
- Destroy the prior ready/back buttons at the top of `createUIButtons()`.

Both use optional chaining so the first (create-time) pass, where nothing exists yet, is a no-op.

## Testing

**Full suite: 785 tests / 105 suites pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Phaser lifecycle cleanup on resize; no auth, networking, or data-path changes.
> 
> **Overview**
> **Fixes duplicate UI and ghost clicks on resize** in `PlayerSelectScene` when `updateLayout()` re-runs `setupCharacters()` and `createUIButtons()` on every scale resize.
> 
> At the start of **`setupCharacters()`**, the PR destroys prior character background circles, name labels, and interactive sprites (and clears `characterSprites`) before rebuilding the grid.
> 
> At the start of **`createUIButtons()`**, it destroys the existing ready and back buttons before creating new ones. Optional chaining keeps the first create pass a no-op.
> 
> Together this stops stacked hit areas and duplicate `launchGame` / character `pointerdown` handlers from orphaned objects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a225c60c2c5ed80483a6083186c121750470b4f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->