### PR TITLE
Add facing and vertical constraints to hit detection

### DIFF
--- a/__tests__/hit_detection_range.test.ts
+++ b/__tests__/hit_detection_range.test.ts
@@ -1,0 +1,57 @@
+jest.mock('../websocket_manager');
+
+import KidsFightScene from '../kidsfight_scene';
+import { setupMockScene } from './test-utils-fix';
+
+const MAX_HEALTH = 100;
+const ATTACK_DAMAGE = 5;
+
+/**
+ * Regression tests for the facing + vertical constraints added to tryAttack.
+ * Previously an attack connected on horizontal distance alone, so a player
+ * could hit an opponent standing behind them or on a platform far above.
+ */
+describe('KidsFightScene - hit detection facing & vertical range', () => {
+  let scene: any;
+  let now: number;
+
+  const makePlayers = (p0: any, p1: any) => {
+    const base = { width: 50, height: 100, setData: jest.fn(), getData: jest.fn().mockReturnValue(false), health: MAX_HEALTH };
+    scene.players = [{ ...base, ...p0 }, { ...base, ...p1 }];
+  };
+
+  beforeEach(() => {
+    scene = new KidsFightScene({});
+    setupMockScene(scene);
+    scene.playerHealth = [MAX_HEALTH, MAX_HEALTH];
+    scene.playerSpecial = [0, 0];
+    scene.playerBlocking = [false, false];
+    scene.updateSpecialPips = jest.fn();
+    scene.updateHealthBar = jest.fn();
+    scene.checkWinner = jest.fn();
+    scene.healthBar1 = scene.add.graphics();
+    scene.healthBar2 = scene.add.graphics();
+    now = Date.now();
+  });
+
+  it('connects when in range, on the same level, and facing the target', () => {
+    // Attacker at x=100 faces right (flipX=false); defender just to the right.
+    makePlayers({ x: 100, y: 100, flipX: false }, { x: 150, y: 100, flipX: true });
+    scene.tryAttack(0, 1, now, false);
+    expect(scene.playerHealth[1]).toBe(MAX_HEALTH - ATTACK_DAMAGE);
+  });
+
+  it('misses when the attacker faces away from the defender', () => {
+    // Attacker faces left (flipX=true) but defender is to the right.
+    makePlayers({ x: 100, y: 100, flipX: true }, { x: 150, y: 100, flipX: false });
+    scene.tryAttack(0, 1, now, false);
+    expect(scene.playerHealth[1]).toBe(MAX_HEALTH); // no damage
+  });
+
+  it('misses when the defender is far above/below (different platform)', () => {
+    // Horizontally close and facing correctly, but a big vertical gap.
+    makePlayers({ x: 100, y: 100, flipX: false }, { x: 150, y: 300, flipX: true });
+    scene.tryAttack(0, 1, now, false);
+    expect(scene.playerHealth[1]).toBe(MAX_HEALTH); // no damage
+  });
+});

--- a/kidsfight_scene.ts
+++ b/kidsfight_scene.ts
@@ -1695,15 +1695,29 @@ export default class KidsFightScene extends Phaser.Scene {
     if (targetBlocking) damage = Math.floor(damage / 2);
 
     // --- ENFORCE RANGE CHECKS ---
-    // Only apply damage if attacker and defender are within range
+    // Only apply damage if attacker and defender are within range.
+    // Each additional constraint is guarded on the relevant field being a real
+    // value so headless tests that only set x still behave as before.
     let inRange = false;
     if (attacker && defender && typeof attacker.x === 'number' && typeof defender.x === 'number') {
       const dist = Math.abs(attacker.x - defender.x);
-      if (special) {
-        inRange = dist <= 120;
-      } else {
-        inRange = dist <= 80;
+      let within = dist <= (special ? 120 : 80);
+
+      // Vertical range: don't hit someone on a different platform far above/below.
+      if (within && typeof attacker.y === 'number' && typeof defender.y === 'number') {
+        const vDist = Math.abs(attacker.y - defender.y);
+        within = vDist <= (special ? 120 : 100);
       }
+
+      // Facing: the attacker must be facing the defender (flipX=false faces
+      // right). Skip when they're at the same x or facing is unknown.
+      if (within && typeof attacker.flipX === 'boolean' && dist > 0) {
+        const attackerFacesRight = !attacker.flipX;
+        const defenderIsToTheRight = defender.x > attacker.x;
+        within = attackerFacesRight === defenderIsToTheRight;
+      }
+
+      inRange = within;
     }
     if (!inRange) {
       // Animation flags still set for test compatibility


### PR DESCRIPTION
## Problem

`tryAttack` decided a hit **purely from horizontal distance** (`|attacker.x - defender.x| <= 80/120`). So a player could land a hit on an opponent **standing behind them**, or one on a platform **far above/below**, as long as they were horizontally close.

## Fix

Two additional constraints in the range check:

- **Vertical**: `|attacker.y - defender.y|` within `100` (`120` for special) — attacks no longer cross platforms.
- **Facing**: the attacker must be facing the defender (`flipX=false` ⇒ faces right).

Each check is **guarded** on the relevant field being a real value, so existing headless tests that only set `x` behave exactly as before (verified: all 148 combat tests still pass).

## Testing

- New `hit_detection_range.test.ts`: connects when in-range/level/facing; misses when facing away; misses on a large vertical gap.
- Full suite: 785 tests pass.

> Note: bounds (100/120 px) are a reasonable default; tune to taste once playtested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core combat hit logic in `tryAttack`, which affects all local and online attacks; guards and tests limit regression risk.
> 
> **Overview**
> **`tryAttack`** no longer treats horizontal distance alone as a hit. After the existing X-range check (80/120 px), damage applies only when vertical separation is within **100** (normal) or **120** (special), and when the attacker’s **`flipX`** faces the defender (skipped if facing is unknown or positions overlap on X).
> 
> Vertical and facing checks run only when **`y`** / **`flipX`** are real values, so headless tests that set **`x`** only keep prior behavior.
> 
> Adds **`hit_detection_range.test.ts`** for in-range hits, facing-away misses, and large vertical-gap misses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b5f50d263acd12306a6b9661cac4aecbe830e80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->