### PR TITLE
Enforce the special-attack cooldown

### DIFF
--- a/__tests__/kidsfight_scene_special_attack.test.ts
+++ b/__tests__/kidsfight_scene_special_attack.test.ts
@@ -206,11 +206,28 @@ describe('KidsFightScene - Special Attack', () => {
       
       // Act
       scene['tryAction'](0, 'special', true);
-      
+
       // Assert - Verify damage was applied
       expect(scene.playerHealth[1]).toBe(initialHealth - 10);
       // Verify special pips were consumed
       expect((scene as any).playerSpecial[0]).toBe(0);
+    });
+
+    it('should block a special that is still on cooldown', () => {
+      const mockPlayer1 = { health: 100, setData: jest.fn(), body: { blocked: { down: true } }, setVelocityX: jest.fn(), setVelocityY: jest.fn(), x: 100 };
+      const mockPlayer2 = { health: 100, setData: jest.fn(), body: { blocked: { down: true } }, setVelocityX: jest.fn(), setVelocityY: jest.fn(), x: 150 };
+      scene.players = [mockPlayer1, mockPlayer2];
+      scene.playerHealth = [100, 100];
+      (scene as any).playerSpecial = [3, 0];
+      scene.gameOver = false;
+      // Pretend a special just fired (cooldown active).
+      (scene as any).lastSpecialTime = [Date.now(), 0];
+
+      scene['tryAction'](0, 'special', true);
+
+      // No damage and pips untouched because the cooldown blocked it.
+      expect(scene.playerHealth[1]).toBe(100);
+      expect((scene as any).playerSpecial[0]).toBe(3);
     });
   });
 

--- a/kidsfight_scene.ts
+++ b/kidsfight_scene.ts
@@ -1580,7 +1580,10 @@ export default class KidsFightScene extends Phaser.Scene {
     if (!this.lastConsecutiveResetTime || this.lastConsecutiveResetTime.length < 2) {
       this.lastConsecutiveResetTime = [0, 0];
     }
-    
+    if (!this.lastSpecialTime || this.lastSpecialTime.length < 2) {
+      this.lastSpecialTime = [0, 0];
+    }
+
     const attacker = this.players?.[playerIndex];
     const defenderIdx = playerIndex === 0 ? 1 : 0;
     const defender = this.players?.[defenderIdx];
@@ -1592,6 +1595,8 @@ export default class KidsFightScene extends Phaser.Scene {
     if (isSpecial) {
       const currentPips = this.playerSpecial?.[playerIndex] ?? 0;
       if (currentPips < 3) return; // not enough pips – abort before any state/animation
+      // Enforce the special cooldown so specials can't be spammed back-to-back.
+      if (now - this.lastSpecialTime[playerIndex] < SPECIAL_COOLDOWN) return;
     }
 
     // Only reset consecutive counter if break is at least 1000ms
@@ -1641,9 +1646,11 @@ export default class KidsFightScene extends Phaser.Scene {
       this.lastConsecutiveResetTime[playerIndex] = now;
       console.log(`[CADENCE] Player ${playerIndex} attack allowed: consecutive=${this.consecutiveAttacks[playerIndex]}, delay was=${ATTACK_COOLDOWN}ms`);
     } else {
-      // For specials, just update lastAttackTime (for shared cooldown)
+      // For specials, update lastAttackTime (shared cooldown) and the special
+      // cooldown timestamp.
       this.lastAttackTime[playerIndex] = now;
       this.lastConsecutiveResetTime[playerIndex] = now;
+      this.lastSpecialTime[playerIndex] = now;
     }
   }
 


### PR DESCRIPTION
## Problem

`SPECIAL_COOLDOWN` (1000ms) and `lastSpecialTime` existed, but `tryAction` never read or wrote them. Specials were gated **only** by the 3-pip requirement, so the declared cooldown had no effect.

## Fix

- Reject a special when `now - lastSpecialTime[player] < SPECIAL_COOLDOWN`.
- Stamp `lastSpecialTime[player]` when a special fires.
- Initialize `lastSpecialTime` alongside the other per-player arrays in `tryAction`.

The pip system already prevents most rapid re-fires (a special resets pips to 0), so this is a belt-and-suspenders enforcement of the intended 1s floor.

## Testing

- New regression test: a special still on cooldown deals no damage and doesn't consume pips.
- Full suite: 786 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small combat-timing change in fight scene logic with a focused unit test; no auth, networking protocol, or data-layer impact.
> 
> **Overview**
> **Special attacks now respect the existing 1s `SPECIAL_COOLDOWN`**, which was defined alongside `lastSpecialTime` but never applied in `tryAction` (only the 3-pip gate ran).
> 
> `tryAction` **initializes** `lastSpecialTime`, **rejects** specials when `now - lastSpecialTime[player] < SPECIAL_COOLDOWN`, and **records** `lastSpecialTime` when a special actually goes through. A regression test confirms a cooldown-blocked special deals no damage and does not spend pips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bda2a8e419709a35614e1bc237ad51531c4c9c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->