### PR TITLE
Make auto-face the single source of truth for player facing

### DIFF
--- a/kidsfight_scene.ts
+++ b/kidsfight_scene.ts
@@ -2456,14 +2456,17 @@ export default class KidsFightScene extends Phaser.Scene {
     const leftDown = this.cursors?.left?.isDown || this.touchButtons?.left?.isDown;
     const rightDown = this.cursors?.right?.isDown || this.touchButtons?.right?.isDown;
     let direction = 0;
+    // Note: facing (flipX) is owned by the auto-face logic in update(), which
+    // makes both players face each other every frame. Setting flipX from the
+    // movement direction here would be immediately overwritten locally and
+    // would send a contradictory flip in the online position_update below, so
+    // we intentionally don't touch flipX for movement.
     if (leftDown) {
       player.setVelocityX?.(-160);
-      player.setFlipX?.(true);
       direction = -1;
       this.updateWalkingAnimation(player);
     } else if (rightDown) {
       player.setVelocityX?.(160);
-      player.setFlipX?.(false);
       direction = 1;
       this.updateWalkingAnimation(player);
     } else {


### PR DESCRIPTION
## Problem

`update()` already flips both players to face each other every frame (the intended fighting-game behavior). But `processKeyboardInput` *also* set `flipX` from the movement direction. That value was:

1. immediately overwritten locally by the auto-face on the same frame, and
2. read into the **online `position_update`** sent a few lines later — so the flip broadcast to the opponent contradicted the auto-face both clients apply.

## Fix

Stop setting `flipX` for movement in `processKeyboardInput`; auto-face in `update()` owns facing. Visually nothing changes (auto-face still runs every frame), but the online `position_update` now carries the auto-face-consistent flip.

`processKeyboardInput` is guarded out of the test environment (`if (typeof jest !== 'undefined') return;`), so no test behavior changes.

## Testing

Full suite: 785 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral fix in one input path; local visuals should be unchanged because auto-face still runs every frame.
> 
> **Overview**
> **`processKeyboardInput`** no longer calls **`setFlipX`** when the player moves left or right. Facing is left to the per-frame auto-face logic in **`update()`** (both fighters face each other based on relative X).
> 
> That removes a conflict where movement-based flips were overwritten locally on the same frame and, in online play, **`flipX`** in **`position_update`** could disagree with what both clients apply after auto-face. Movement velocity, walk animation, and **`direction`** are unchanged; a short comment documents why **`flipX`** is not set here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 738a568d3ce6ee1a72109b12edcf732a33a70638. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->