### PR TITLE
Consolidate player gravity to a single source (500)

### DIFF
--- a/kidsfight_scene.ts
+++ b/kidsfight_scene.ts
@@ -1099,9 +1099,8 @@ export default class KidsFightScene extends Phaser.Scene {
           player.setOrigin(0.5, 1.0);
           player.setScale(0.4);
           player.setBounce(0.2);
-          if (player.body) {
-            player.body.setGravityY(300);
-          }
+          // Players use the world gravity (500) — no per-body override, which
+          // previously stacked on top of the world value.
           player.setCollideWorldBounds(true);
           if (player.setSize) player.setSize(64, 128, true);
         }

--- a/main.ts
+++ b/main.ts
@@ -27,7 +27,10 @@ const config: Phaser.Types.Core.GameConfig = {
   physics: {
     default: 'arcade',
     arcade: {
-      gravity: { y: 200 }, // Lower gravity for much higher jumps
+      // Effective player gravity. Previously this was 200 here plus a per-body
+      // setGravityY(300) on each player (Arcade adds the two), for 500 total.
+      // Consolidated to a single value so jump height has one source of truth.
+      gravity: { y: 500 },
       debug: false
     }
   }


### PR DESCRIPTION
## Problem

World gravity was `200` (commented *"Lower gravity for much higher jumps"*) while each player's body then added `setGravityY(300)`. Arcade physics **sums** world + body gravity, so the effective player gravity was **500** — the opposite of the "lower gravity" comment, and jump tuning was split across `main.ts` and `kidsfight_scene.ts`.

## Fix

Set the world gravity to `500` and drop the per-body `setGravityY(300)` override. Players are the only dynamic bodies (platforms are static, effects are non-physics graphics), so the **effective gravity and jump height are unchanged** — it now just has one source of truth.

## Testing

- Physics/main/positioning suites pass (50 tests); no test asserts the old `200`/`300` values.
- Full suite: passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Physics-only refactor intended to preserve jump/fall feel; no auth or data paths touched, though manual play is still the best check that jumps feel unchanged.
> 
> **Overview**
> **Player gravity** is now defined only in `main.ts` as world `gravity.y: 500`, with comments explaining that Arcade sums world and per-body gravity.
> 
> **`KidsFightScene`** no longer calls `setGravityY(300)` on each fighter, so jump/fall tuning is not split across two files. Effective pull on players stays **500** (previously 200 + 300), so gameplay should feel the same while configuration matches reality.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37d9228ded5462489708edc27a6a3536bbf48417. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->