### PR TITLE
Add auto-reconnect with backoff to WebSocketManager

### DIFF
--- a/__tests__/websocket_reconnect.test.ts
+++ b/__tests__/websocket_reconnect.test.ts
@@ -1,0 +1,78 @@
+import { WebSocketManager } from '../websocket_manager';
+
+/**
+ * Tests for auto-reconnect: an unexpected close should trigger a backoff
+ * reconnect, while a manual disconnect() should not.
+ */
+describe('WebSocketManager auto-reconnect', () => {
+  let created: any[];
+  const factory = () => {
+    const ws: any = {
+      url: '',
+      readyState: 1,
+      send: jest.fn(),
+      close: jest.fn(),
+      _listeners: {} as Record<string, Function[]>,
+      addEventListener(type: string, fn: Function) {
+        (this._listeners[type] = this._listeners[type] || []).push(fn);
+      },
+      removeEventListener(type: string, fn: Function) {
+        this._listeners[type] = (this._listeners[type] || []).filter((l: Function) => l !== fn);
+      },
+      onopen: null as any,
+      onclose: null as any,
+      onerror: null as any,
+      _trigger(type: string, data?: any) {
+        if (type === 'open' && this.onopen) this.onopen({ type: 'open' });
+        if (type === 'close' && this.onclose) this.onclose({ type: 'close' });
+        (this._listeners[type] || []).forEach((l: Function) => l(data));
+      },
+    };
+    created.push(ws);
+    return ws;
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    created = [];
+    WebSocketManager.resetInstance();
+  });
+
+  afterEach(() => {
+    WebSocketManager.resetInstance();
+    jest.useRealTimers();
+  });
+
+  it('reconnects after an unexpected close', async () => {
+    const mgr = WebSocketManager.getInstance(factory as any);
+    const p = mgr.connect('ws://test');
+    created[0]._trigger('open');
+    await p;
+    expect(created.length).toBe(1);
+    expect(mgr.isConnected()).toBe(true);
+
+    // Simulate the server dropping the connection.
+    created[0]._trigger('close');
+    expect(mgr.isConnected()).toBe(false);
+
+    // Backoff is 1000ms for the first attempt.
+    jest.advanceTimersByTime(1000);
+    expect(created.length).toBe(2); // a new socket was created
+
+    created[1]._trigger('open');
+    expect(mgr.isConnected()).toBe(true);
+  });
+
+  it('does not reconnect after a manual disconnect', async () => {
+    const mgr = WebSocketManager.getInstance(factory as any);
+    const p = mgr.connect('ws://test');
+    created[0]._trigger('open');
+    await p;
+
+    mgr.disconnect();
+    created[0]._trigger('close');
+
+    jest.advanceTimersByTime(20000);
+    expect(created.length).toBe(1); // no reconnect
+  });
+});

--- a/websocket_manager.ts
+++ b/websocket_manager.ts
@@ -57,6 +57,12 @@ class WebSocketManager {
   private _onConnectionCallback: ((isConnected: boolean) => void) | null = null;
   private _boundMessageCallback: ((event: MessageEvent) => void) | null = null;
   private _webSocketFactory: (url: string) => WebSocket;
+  // Auto-reconnect state
+  private _shouldReconnect: boolean = false;
+  private _lastUrl: string | null = null;
+  private _reconnectAttempts: number = 0;
+  private _maxReconnectAttempts: number = 5;
+  private _reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
   private constructor(webSocketFactory?: (url: string) => WebSocket) {
     this._webSocketFactory = webSocketFactory || ((url: string) => new WebSocket(url));
@@ -102,6 +108,13 @@ class WebSocketManager {
     if (!wsUrl) {
       wsUrl = getWebSocketUrl();
     }
+    // Remember the URL and (re)enable auto-reconnect for this connection.
+    this._lastUrl = wsUrl;
+    this._shouldReconnect = true;
+    if (this._reconnectTimer) {
+      clearTimeout(this._reconnectTimer);
+      this._reconnectTimer = null;
+    }
     if (this._ws) {
       console.warn(`[WSM] WebSocket already connected [${this._debugInstanceId}]`);
       return Promise.resolve(this._ws);
@@ -117,6 +130,7 @@ class WebSocketManager {
         this._ws.onopen = () => {
           console.log('[WSM][DIAG] _ws.onopen called');
           console.log(`[WSM] Connected to server [${this._debugInstanceId}]`);
+          this._reconnectAttempts = 0; // reset backoff on a successful connection
           this._onConnectionCallback?.(true);
           if (this._onMessageCallback) {
             this._boundMessageCallback = (e: MessageEvent) => {
@@ -169,6 +183,10 @@ class WebSocketManager {
             this._onCloseCallback?.(event);
           }
           this._onConnectionCallback?.(false);
+          // Attempt to recover from an unexpected drop (not a manual disconnect).
+          if (this._shouldReconnect && wasConnected) {
+            this._scheduleReconnect();
+          }
         };
 
         this._ws.onerror = (error: Event) => {
@@ -184,7 +202,47 @@ class WebSocketManager {
     });
   }
 
+  /**
+   * Schedule a reconnect attempt using exponential backoff (1s, 2s, 4s, …,
+   * capped at 10s), up to _maxReconnectAttempts. The host flag, room code and
+   * message callback are preserved across the reconnect.
+   */
+  private _scheduleReconnect(): void {
+    if (this._reconnectTimer) return; // already scheduled
+    if (this._reconnectAttempts >= this._maxReconnectAttempts) {
+      console.warn(`[WSM] Giving up reconnect after ${this._reconnectAttempts} attempts [${this._debugInstanceId}]`);
+      return;
+    }
+    const attempt = this._reconnectAttempts + 1;
+    const delay = Math.min(1000 * Math.pow(2, this._reconnectAttempts), 10000);
+    console.log(`[WSM] Scheduling reconnect attempt ${attempt} in ${delay}ms [${this._debugInstanceId}]`);
+    this._reconnectTimer = setTimeout(() => {
+      this._reconnectTimer = null;
+      if (!this._shouldReconnect || this._ws) return;
+      this._reconnectAttempts = attempt;
+      const wasHost = this._isHost;
+      const roomCode = this._roomCode;
+      this.connect(this._lastUrl || undefined, roomCode || undefined)
+        .then(() => {
+          // connect() may clear these; restore the pre-drop identity.
+          this._isHost = wasHost;
+          if (roomCode) this._roomCode = roomCode;
+        })
+        .catch(() => {
+          // Connection failed again — queue the next backoff step.
+          if (this._shouldReconnect) this._scheduleReconnect();
+        });
+    }, delay);
+  }
+
   public disconnect(code?: number, reason?: string): void {
+    // A manual disconnect is intentional: stop auto-reconnecting.
+    this._shouldReconnect = false;
+    this._reconnectAttempts = 0;
+    if (this._reconnectTimer) {
+      clearTimeout(this._reconnectTimer);
+      this._reconnectTimer = null;
+    }
     if (this._ws) {
       try {
         if (this._boundMessageCallback) {


### PR DESCRIPTION
## Problem

An unexpected socket drop was **terminal**: `onclose` nulled `_ws` and every later `send()` silently returned `false`, with no recovery. A mid-match network blip froze the online game permanently, with no error surfaced.

## Fix

Add reconnect handling to `WebSocketManager`:

- Record the connect URL and enable reconnect on `connect()`.
- On an **unexpected** close (not a manual `disconnect()`), schedule a reconnect with **exponential backoff** (1s → 2s → 4s → …, capped at 10s), up to 5 attempts.
- Preserve host flag, room code, and message callback across the reconnect.
- Reset the backoff on a successful open.
- `disconnect()` marks the close intentional and cancels any pending reconnect.

Scenes already observe connection state via `setConnectionCallback` (fires `false` on drop, `true` on recovery), so UI can react without further wiring.

## Testing

- New `websocket_reconnect.test.ts` (fake timers): reconnects after an unexpected close; does **not** reconnect after a manual disconnect.
- Full suite: 785 tests pass, no leaked timers/open handles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core online connection lifecycle and reconnect timing; incorrect backoff or state restoration could desync matches or duplicate sessions, though scope is limited to WebSocketManager and tests.
> 
> **Overview**
> **`WebSocketManager`** now recovers from unexpected socket drops instead of leaving online play permanently disconnected.
> 
> On **`connect()`**, the manager stores the URL and turns reconnect on; after an unintended close it schedules retries with **exponential backoff** (1s → 2s → 4s…, max 10s delay, up to **5** attempts). Successful **`onopen`** resets the attempt counter. **`disconnect()`** marks the close as intentional, clears pending timers, and stops further retries. Reconnect reuses the saved URL and restores **host**, **room code**, and message handling after **`connect()`** runs.
> 
> **`setConnectionCallback`** still fires `false` on drop and `true` on recovery, so scenes like **`online_mode_scene`** can react without new wiring.
> 
> New **`websocket_reconnect.test.ts`** (fake timers) covers unexpected-close reconnect and no reconnect after manual **`disconnect()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef7247453dc31d3871f5d1fbf25c69da46ac40b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->