### PR TITLE
Update remaining stale tryAttack-signature assertion

### DIFF
--- a/__tests__/kidsfight_scene.test.ts
+++ b/__tests__/kidsfight_scene.test.ts
@@ -644,13 +644,10 @@ describe('KidsFightScene', () => {
     it('should handle player attack', () => {
       const attackAction = {type: 'attack', playerIndex: 0};
       scene.handleRemoteAction(attackAction);
-      expect(scene.tryAttack).toHaveBeenCalledWith(
-          0,
-          player1,
-          player2,
-          expect.any(Number),
-          false
-      );
+      // A remote attack applies exactly once, via the canonical
+      // (attackerIdx, defenderIdx, now, special) signature.
+      expect(scene.tryAttack).toHaveBeenCalledTimes(1);
+      expect(scene.tryAttack).toHaveBeenCalledWith(0, 1, expect.any(Number), false);
     });
 
     it('should handle player block', () => {


### PR DESCRIPTION
## Problem

PR #5 (remove double remote-attack damage) changed `handleRemoteAction` to call `tryAttack` **once** with the canonical `(attackerIdx, defenderIdx, now, special)` signature and updated `kidsfight_scene_handle_remote_action.test.ts` — but an equivalent assertion in **`kidsfight_scene.test.ts`** still expected the old object signature `(0, player1, player2, …)`. That test has been **failing on `main`** since #5 merged.

## Fix

Update the assertion to expect a single canonical call:

```ts
expect(scene.tryAttack).toHaveBeenCalledTimes(1);
expect(scene.tryAttack).toHaveBeenCalledWith(0, 1, expect.any(Number), false);
```

## Testing

Full suite is green again: **797 tests / 108 suites pass** (this was the only broken test on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no production code touched.
> 
> **Overview**
> Fixes a **failing test on `main`** left over after PR #5 changed how remote attacks invoke `tryAttack`.
> 
> The **"should handle player attack"** case in `kidsfight_scene.test.ts` still expected the old call shape `(0, player1, player2, timestamp, false)`. It now asserts **one** call with the canonical indices and args: `(0, 1, expect.any(Number), false)`, matching `handleRemoteAction` and the dedicated remote-action tests updated in #5.
> 
> No runtime or scene logic changes—test expectations only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f22a53b0e62ab079754b5e4fc532908c72718ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->